### PR TITLE
fix(cli): support internal projects without client selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ All commands support `--format json` (global class option). Mutation commands (`
 ## Planning & Issue Tracking
 
 - Design specs and implementation plans go in `docs/plans/` — nowhere else.
+- **Plans must be tool-agnostic.** Do not include instructions that depend on a specific agent platform, plugin, skill system, or external workflow framework unless the user explicitly asks for that integration. In particular, do not add boilerplate like "For agentic workers", "REQUIRED SUB-SKILL", or references to named plugins/tools in plan headers.
 - **Every plan must include these two bookend tasks — no exceptions:**
   - **Task 0 (first):** Post the full design spec to the related GitHub issue (not a link, not a summary — the full spec text). If no issue exists, create one first.
   - **Last task:** Update or create ALL related documentation: README, AGENTS.md, and any skill files (e.g. `skills/*/SKILL.md`) that reference changed behavior or conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,5 +142,6 @@ npx skills add https://skills.sh/parasquid/freshbooks-cli/freshbooks
 ## FreshBooks API Gotchas
 
 - **Services are project-scoped.** The global `/comments/business/{id}/services` endpoint often returns empty. Services are embedded in project JSON under the `services` array. Use `fb projects --format json` to see available services per project.
+- **Internal projects are clientless.** Internal projects come back with `internal: true` and `client_id: null`. For project-backed internal entries, omit `client_id` from create/update payloads instead of inventing a placeholder client. CLI output should render these as `Internal`.
 - **Dates must be full datetimes.** The API rejects bare dates like `"2026-03-04"` — use `"2026-03-04T00:00:00Z"`. The CLI's `normalize_datetime` helper handles this.
 - **PUT replaces, not patches.** Updating a time entry replaces the entire record. The `edit` command sends all existing fields (client_id, project_id, service_id, duration, note, started_at, is_logged) alongside any changed fields to avoid wiping data.

--- a/README.md
+++ b/README.md
@@ -176,9 +176,15 @@ Time entry created!
 ```bash
 fb log --client "Acme Corp" --project "Website Redesign" --service "Development" --duration 2.5 --note "Built API endpoints" --yes
 fb log --client "Acme Corp" --duration 2.5 --note "Work" --yes --format json  # JSON output with entry ID
+fb log --project "AI Service Design" --service "Meetings" --duration 0.5 --note "Calum 1:1" --yes --format json
+fb log --internal --project "AI Service Design" --service "Meetings" --duration 0.5 --note "Calum 1:1" --yes --format json
 ```
 
-**Note:** Services are project-scoped. Use `fb projects --format json` to see available services per project.
+**Notes:**
+- Services are project-scoped. Use `fb projects --format json` to see available services per project.
+- Internal projects can be logged without `--client`.
+- When `--project` is supplied without `--client`, the CLI performs a fresh project lookup and derives the client from that project. Internal projects omit `client_id`.
+- `--internal` requires `--project` and conflicts with `--client`.
 
 ### `fb entries`
 
@@ -224,6 +230,8 @@ fb projects --client "Acme Corp"   # Filter by client name
 fb projects --format json          # Machine-readable output
 ```
 
+Internal projects display as `Internal` in the Client column.
+
 ### `fb services`
 
 List business-level services. Note: most services in FreshBooks are project-scoped — use `fb projects --format json` to see services per project.
@@ -258,6 +266,8 @@ This Month (2026-03-01 to 2026-03-04)
 fb status --format json   # Structured JSON with entries and totals
 ```
 
+Internal entries are shown as `Internal / <Project Name>`.
+
 ### `fb delete`
 
 Delete a time entry. Interactive by default — shows today's entries for selection. Use `--id` to skip the picker.
@@ -280,8 +290,12 @@ fb edit --id 12345 --duration 1.5 --yes  # Scripted — update duration, skip co
 fb edit --id 12345 --note "Updated note" --date 2026-03-01 --yes
 fb edit --id 12345 --service "Meetings" --yes  # Change service
 fb edit --id 12345 --client "Globex Inc" --project "Mobile App" --yes
+fb edit --id 12345 --project "AI Service Design" --service "Meetings" --yes
+fb edit --id 12345 --internal --project "AI Service Design" --service "Meetings" --yes
 fb edit --id 12345 --duration 2 --yes --format json  # JSON output
 ```
+
+When `--project` points to an internal project, `fb edit` omits `client_id` from the update payload so the entry becomes clientless.
 
 ### `fb cache`
 
@@ -338,5 +352,6 @@ fb status --format json
 - `--format json` — structured output on all commands
 - `--no-interactive` — explicit non-interactive mode (also auto-detected)
 - `--id` — required for edit/delete in non-interactive mode
-- `--client`, `--duration`, `--note` — required for log in non-interactive mode (with multiple clients)
+- `--client`, `--duration`, `--note` — required for client-backed log resolution in non-interactive mode (with multiple clients)
+- `--internal` — force internal-project resolution; requires `--project` and conflicts with `--client`
 - `--service` — specify service by name (services are project-scoped; see `fb projects --format json`)

--- a/docs/plans/2026-04-21-internal-project-client-resolution-design.md
+++ b/docs/plans/2026-04-21-internal-project-client-resolution-design.md
@@ -1,0 +1,311 @@
+# Internal Project Client Resolution Design
+
+Date: 2026-04-21
+Issue: #2
+Branch: `2-fb-log-requires-client-even-for-internal-projects`
+
+## Summary
+
+`fb log` currently forces client resolution before project resolution. That makes it impossible to log directly to an internal FreshBooks project, because those projects are represented by `internal: true` and `client_id: null`.
+
+The same mismatch exists in `fb edit`: changing only the project keeps the old `client_id`, so moving an entry onto an internal project preserves an invalid client association.
+
+This design updates both `log` and `edit` so project selection can drive client resolution when needed. Internal projects will be treated as clientless by omitting `client_id` from the API payload. A new explicit `--internal` flag will be added for commands where the user wants to say "this entry should have no client".
+
+## Goals
+
+- Allow `fb log --project "<internal project>" ...` to work without `--client`.
+- Allow explicit client clearing from the CLI with `--internal`.
+- Ensure `fb edit` can move an existing entry onto an internal project and end up with `client_id: null`.
+- Keep normal cached/default client behavior for the existing client-first flows.
+- Update help text and docs so internal-project behavior is obvious.
+- Ensure read/display commands render internal projects and entries clearly.
+
+## Non-Goals
+
+- Refactor every selector in the CLI into a new shared abstraction.
+- Change how FreshBooks auth, token refresh, or cache expiration works globally.
+- Broaden the feature into full project/client consistency validation for unrelated commands.
+
+## Verified Facts
+
+### FreshBooks documentation
+
+- Time entries expose an `internal` boolean meaning the entry is not assigned to a client.
+- Projects expose an `internal` boolean.
+
+Sources:
+- https://www.freshbooks.com/api/time_entries
+- https://www.freshbooks.com/api/project
+
+### Live API behavior
+
+Read-only checks against the current account confirmed:
+
+- Internal projects are returned with `internal: true` and `client_id: null`.
+- Existing time entries on internal projects are returned with `project_id` set, `client_id: null`, and `internal: false`.
+
+Implication:
+
+- For project-backed internal entries, the safe payload behavior is to omit `client_id`.
+- This design should not force `internal: true` in the create/update payload for the internal-project path.
+
+## Current Problem
+
+### `log`
+
+Current flow:
+
+1. `select_client`
+2. `select_project(client["id"], defaults)`
+3. `select_service`
+4. build payload with `"client_id" => client["id"]`
+
+This prevents internal projects from ever being selected unless the user supplies an unrelated client, which produces incorrect data.
+
+### `edit`
+
+Current flow builds a full replacement payload from the existing entry, including:
+
+- `client_id`
+- `project_id`
+- `service_id`
+
+If the user changes only `--project`, the old `client_id` is preserved. Moving an entry from a client-backed project to an internal project therefore keeps the old client attached.
+
+## CLI Contract
+
+### New flag
+
+Add `--internal` to:
+
+- `fb log`
+- `fb edit`
+
+Semantics:
+
+- `--internal` means the resulting entry should have no client association.
+- `--internal` conflicts with `--client`.
+- `--internal` requires `--project`, because this repo resolves services and internal status from a concrete project.
+
+### Project-driven inference
+
+If `--project` is passed without `--client`, the command will resolve the named project from a fresh all-projects fetch and derive client handling from the selected project:
+
+- internal project: omit `client_id`
+- client-backed project: use that project's `client_id`
+
+This behavior applies to both `log` and `edit`.
+
+### Mismatch handling
+
+Abort with a clear error when:
+
+- `--client` and `--internal` are both passed
+- `--internal` is passed for a project that is not internal
+- `--client` is passed together with a project whose FreshBooks data shows `internal: true` or `client_id: null`
+
+## Resolution Strategy
+
+Introduce a focused internal resolution step used by both `log` and `edit`.
+
+### Normal client-first path
+
+Keep the existing flow when:
+
+- no `--project` is passed, and
+- no `--internal` is passed
+
+This preserves current defaults and cache behavior.
+
+### Project-first path
+
+Use a fresh all-projects lookup when:
+
+- `--project` is passed without `--client`, or
+- `--internal` is passed, or
+- `edit` changes `--project`
+
+Project-first resolution returns:
+
+- the selected project
+- whether the project is internal
+- the effective client id, if any
+
+Rules:
+
+- A project is internal if `project["internal"] == true` or `project["client_id"].nil?`.
+- For internal projects, the effective client id is absent.
+- For non-internal projects, the effective client id is `project["client_id"]`.
+
+## Command Behavior
+
+### `fb log`
+
+#### Existing behavior preserved
+
+- `fb log --client "Acme" ...` continues to use the current client-first path.
+- No-project logging without `--internal` continues to use cached/default client selection.
+
+#### New behavior
+
+- `fb log --project "<internal project>" ...` works without `--client`.
+- `fb log --internal --project "<internal project>" ...` explicitly requests a clientless entry.
+- `fb log --project "<client-backed project>" ...` may derive the client from that project even when `--client` is omitted.
+
+Payload behavior:
+
+- internal project: include `project_id` and optional `service_id`, omit `client_id`
+- client-backed project: include `client_id`, `project_id`, and optional `service_id`
+
+### `fb edit`
+
+#### Existing behavior preserved
+
+- `fb edit --id <id> --client "Acme" ...` continues to set `client_id` explicitly.
+- Edits that do not touch project/client fields keep their current semantics.
+
+#### New behavior
+
+- `fb edit --id <id> --project "<internal project>" ...` updates the entry so `client_id` is omitted from the update payload.
+- `fb edit --id <id> --internal --project "<internal project>" ...` does the same explicitly.
+- `fb edit --id <id> --project "<client-backed project>" ...` synchronizes `client_id` to the selected project's client when no explicit `--client` is given.
+
+This keeps project/client relationships coherent and makes the manual real-world verification possible.
+
+### Read and display support
+
+These commands do not need new flags, but they should render internal records clearly:
+
+- `entries`
+- `status`
+- interactive entry pickers used by `edit` and `delete`
+- `projects`
+
+Rules:
+
+- internal entries should display `Internal` as the client label instead of blank output
+- internal projects should display `Internal` in project listings instead of `-`
+- per-client summaries should group internal entries under `Internal`
+
+## Services
+
+Service resolution stays project-scoped.
+
+Rules:
+
+- If the selected project includes embedded `services`, use that list.
+- Internal projects still use their own project services.
+- No new service-selection model is introduced.
+
+## Cache Policy
+
+The repo currently caches raw project data for 10 minutes. Internal detection is more sensitive to stale project metadata than the existing client-first flow, so project-driven internal resolution will bypass the normal cache only when needed.
+
+Fresh fetch required for:
+
+- `log` with `--internal`
+- `log` with `--project` and no `--client`
+- `edit` when `--project` is being changed
+
+Normal cache behavior preserved for:
+
+- client-first `log`
+- commands unrelated to project-driven internal detection
+
+Additional rule:
+
+- never persist `nil` as a cached or default `client_id`
+
+## Defaults Behavior
+
+Defaults should continue to store only concrete IDs.
+
+Rules:
+
+- internal runs may save `project_id` and `service_id`
+- internal runs must not save `client_id: nil`
+- normal client-backed runs keep saving `client_id`, `project_id`, and `service_id` as today
+
+This avoids stale default-client reuse while keeping useful project/service defaults.
+
+## Error Handling
+
+Use clear aborts for:
+
+- project not found
+- internal flag used without a project
+- internal flag used with a non-internal project
+- explicit client combined with an internal project
+- service not found in the selected project's services
+
+Error messages should state the exact mismatch so the user can correct the command without guessing.
+
+## Testing
+
+### Automated repo tests
+
+Add CLI specs covering:
+
+- `log` with `--project` pointing to an internal project and no `--client`
+- `log` with `--internal --project <internal>`
+- `log` conflict: `--client` with `--internal`
+- `log` conflict: explicit client with an internal project
+- `edit` moving an entry onto an internal project by changing only `--project`
+- `edit` with `--internal --project <internal>`
+- `edit` moving an entry onto a client-backed project and syncing `client_id`
+- defaults persistence for internal runs without storing `client_id: nil`
+- forced fresh project resolution on internal/project-driven paths
+
+Assertions should verify payload shape, especially that internal-project requests omit `client_id`.
+
+### Manual verification
+
+Manual verification will be done by intentionally editing one existing meeting entry that is currently parked on a client-backed project and moving it onto an internal project.
+
+Verification steps:
+
+1. Identify one existing meeting entry currently attached to a client-backed project.
+2. Edit it to use the intended internal project.
+3. Read the updated entry back through `fb entries --format json`.
+4. Confirm the resulting record has:
+   - the internal `project_id`
+   - `client_id: null`
+
+This verification is intentionally manual and not automated in the test suite.
+
+## Documentation And Help Updates
+
+Update all user-facing guidance that currently implies `--client` is always required.
+
+Files expected to change:
+
+- CLI help text in `lib/freshbooks/cli.rb`
+- `README.md`
+- `AGENTS.md`
+- `skills/freshbooks/SKILL.md`
+
+Documentation must explain:
+
+- what `--internal` means
+- that internal projects can be logged without `--client`
+- that internal entries and projects display as `Internal` in CLI output
+- that project-driven internal detection uses a fresh project lookup
+- that normal client-first flows still use cached/default behavior
+- that `edit` also supports moving entries onto internal projects
+
+## Risks
+
+- Project title matching remains name-based and can still be ambiguous if duplicate titles exist.
+- Forced fresh project fetches add a small extra API cost on the internal/project-driven paths.
+- The existing token refresh race can interfere with live verification if commands are run in parallel; verification should be done serially.
+
+## Recommended Implementation Shape
+
+Keep the change narrow:
+
+- add a shared project/client resolution helper for `log` and `edit`
+- do not refactor the entire command layer
+- update payload construction and defaults handling only where internal-project behavior requires it
+
+This keeps the change aligned with issue #2 while fixing the adjacent `edit` inconsistency required for real-world verification.

--- a/docs/plans/2026-04-21-internal-project-client-resolution-plan.md
+++ b/docs/plans/2026-04-21-internal-project-client-resolution-plan.md
@@ -1,0 +1,887 @@
+# Internal Project Client Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow `fb log` and `fb edit` to work correctly with internal FreshBooks projects, keep `client_id` omitted for internal project entries, and render internal records clearly in CLI output.
+
+**Architecture:** Keep the change narrow inside `FreshBooks::CLI::Commands` by adding a shared project/client resolution layer for `log` and `edit`, then reuse small display helpers for `entries`, `status`, `projects`, and interactive pickers. Preserve existing cached/default client behavior for normal flows while forcing a fresh project lookup only on internal or project-driven resolution paths.
+
+**Tech Stack:** Ruby, Thor, RSpec with rspec-given, WebMock, FreshBooks REST API via HTTParty
+
+---
+
+## File Map
+
+- Modify: `lib/freshbooks/cli.rb`
+  Responsibility: add `--internal`, implement project-first resolution for `log` and `edit`, omit `client_id` for internal-project payloads, add internal display helpers, and update help JSON text.
+- Modify: `spec/freshbooks/cli_spec.rb`
+  Responsibility: add failing and passing CLI specs for internal-project logging/editing, display labels, and defaults behavior.
+- Modify: `README.md`
+  Responsibility: document `--internal`, internal project logging without `--client`, and updated non-interactive behavior.
+- Modify: `AGENTS.md`
+  Responsibility: keep repository instructions aligned with new internal-project behavior and manual verification guidance.
+- Modify: `skills/freshbooks/SKILL.md`
+  Responsibility: update the installed repo skill so it no longer claims `--client` is always required for deterministic logging.
+- Verify manually against live data:
+  Responsibility: move one Calum 1:1 entry from the parked CoinGecko project to `AI Service Design` and read it back serially.
+
+### Task 0: Post The Approved Design Spec To Issue #2
+
+**Files:**
+- Modify: GitHub issue `#2`
+- Source: `docs/plans/2026-04-21-internal-project-client-resolution-design.md`
+
+- [x] **Step 1: Post the full approved spec text to the issue**
+
+Run:
+
+```bash
+gh issue comment 2 --body-file docs/plans/2026-04-21-internal-project-client-resolution-design.md
+```
+
+Expected: `gh` prints the new comment URL.
+
+- [x] **Step 2: Record the posted comment URL in the implementation notes**
+
+Observed result:
+
+```text
+https://github.com/parasquid/freshbooks-cli/issues/2#issuecomment-4289848278
+```
+
+- [x] **Step 3: Commit the design doc before implementation planning**
+
+Run:
+
+```bash
+git add docs/plans/2026-04-21-internal-project-client-resolution-design.md
+git commit -m "docs(plans): add internal project client resolution design"
+```
+
+Expected: a commit exists on branch `2-fb-log-requires-client-even-for-internal-projects`.
+
+### Task 1: Write Failing Specs For Internal Logging Resolution
+
+**Files:**
+- Modify: `spec/freshbooks/cli_spec.rb`
+- Modify later: `lib/freshbooks/cli.rb`
+- Test: `spec/freshbooks/cli_spec.rb`
+
+- [ ] **Step 1: Add failing `log` specs for internal-project payload omission and flag conflicts**
+
+Insert `describe "log"` examples near the existing non-interactive `log` coverage:
+
+```ruby
+    context "non-interactive with --project on an internal project and no --client" do
+      Given {
+        allow($stdin).to receive(:tty?).and_return(false)
+
+        stub_request(:get, clients_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "clients" => [
+                  { "id" => 10, "organization" => "Acme Corp", "fname" => "J", "lname" => "D" },
+                  { "id" => 11, "organization" => "Globex Inc", "fname" => "G", "lname" => "X" }
+                ],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+
+        stub_request(:get, projects_url)
+          .with(query: hash_including("page" => 1, "per_page" => 100))
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "projects" => [
+                  {
+                    "id" => 12375603,
+                    "title" => "AI Service Design",
+                    "client_id" => nil,
+                    "internal" => true,
+                    "active" => true,
+                    "services" => [{ "id" => 15770631, "name" => "Meetings", "billable" => true }]
+                  }
+                ],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+
+        stub_request(:post, time_entries_url)
+          .with { |req|
+            payload = JSON.parse(req.body)
+            entry = payload.fetch("time_entry")
+            entry["project_id"] == 12375603 &&
+              entry["service_id"] == 15770631 &&
+              !entry.key?("client_id")
+          }
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "result" => { "time_entry" => { "id" => 777 } } }.to_json
+          )
+      }
+      When(:output) {
+        capture_stdout {
+          FreshBooks::CLI::Commands.start([
+            "log", "--project", "AI Service Design", "--service", "Meetings",
+            "--duration", "0.5", "--note", "Calum 1:1", "--yes", "--format", "json"
+          ])
+        }
+      }
+      Then { JSON.parse(output)["result"]["time_entry"]["id"] == 777 }
+      And  { assert_requested(:post, time_entries_url) }
+    end
+
+    context "non-interactive with --internal and --client aborts" do
+      Given { allow($stdin).to receive(:tty?).and_return(false) }
+      When(:result) {
+        invoke_cli_command(
+          :log,
+          client: "Acme Corp",
+          project: "AI Service Design",
+          duration: 0.5,
+          note: "Calum 1:1",
+          yes: true,
+          internal: true,
+          no_interactive: false,
+          stub_abort: true
+        )
+      }
+      Then { result.is_a?(CliAbort) }
+    end
+
+    context "non-interactive with --internal on a client-backed project aborts" do
+      Given {
+        allow($stdin).to receive(:tty?).and_return(false)
+        stub_log_apis
+        stub_request(:get, projects_url)
+          .with(query: hash_including("page" => 1, "per_page" => 100))
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "projects" => [
+                  { "id" => 20, "title" => "Client Project", "client_id" => 10, "internal" => false, "active" => true }
+                ],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+      }
+      When(:result) {
+        invoke_cli_command(
+          :log,
+          project: "Client Project",
+          duration: 0.5,
+          note: "Calum 1:1",
+          yes: true,
+          internal: true,
+          no_interactive: false,
+          stub_abort: true
+        )
+      }
+      Then { result.is_a?(CliAbort) }
+    end
+```
+
+- [ ] **Step 2: Run the targeted `log` specs and confirm they fail before implementation**
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/cli_spec.rb \
+  --example "non-interactive with --project on an internal project and no --client" \
+  --example "non-interactive with --internal and --client aborts" \
+  --example "non-interactive with --internal on a client-backed project aborts"
+```
+
+Expected: FAIL because `log` still requires client-first resolution and still sends `client_id`.
+
+- [ ] **Step 3: Implement shared project/client resolution helpers and the `log` path**
+
+Add `method_option :internal` to `log`, then add helper methods in `lib/freshbooks/cli.rb`:
+
+```ruby
+      method_option :internal, type: :boolean, default: false, desc: "Log to an internal project with no client"
+      def log
+        Auth.valid_access_token
+        defaults = Auth.load_defaults
+
+        context = resolve_entry_context_for_log(defaults)
+        project = context[:project]
+        service = select_service(defaults, project)
+        date = pick_date
+        duration_hours = pick_duration
+        note = pick_note
+
+        unless options[:format] == "json"
+          puts "\n--- Time Entry Summary ---"
+          puts "  Client:   #{display_client_label(context[:client], project)}"
+          puts "  Project:  #{project ? project["title"] : "(none)"}"
+          puts "  Service:  #{service ? service["name"] : "(none)"}"
+          puts "  Date:     #{date}"
+          puts "  Duration: #{duration_hours}h"
+          puts "  Note:     #{note}"
+          puts "--------------------------\n\n"
+        end
+
+        entry = {
+          "is_logged" => true,
+          "duration" => (duration_hours * 3600).to_i,
+          "note" => note,
+          "started_at" => normalize_datetime(date)
+        }
+        entry["client_id"] = context[:client]["id"] if context[:client]
+        entry["project_id"] = project["id"] if project
+        entry["service_id"] = service["id"] if service
+
+        result = Api.create_time_entry(entry)
+        puts(options[:format] == "json" ? JSON.pretty_generate(result) : "Time entry created!")
+
+        new_defaults = {}
+        new_defaults["client_id"] = context[:client]["id"] if context[:client]
+        new_defaults["project_id"] = project["id"] if project
+        new_defaults["service_id"] = service["id"] if service
+        Auth.save_defaults(new_defaults)
+      end
+
+      def resolve_entry_context_for_log(defaults)
+        validate_internal_flag_usage!
+
+        if options[:project] && (!options[:client] || options[:internal])
+          project = resolve_project_by_name(options[:project], force: true)
+          assert_internal_project_match!(project)
+          client = project_internal?(project) ? nil : resolve_client_for_project(project, defaults)
+          return { client: client, project: project }
+        end
+
+        client = select_client(defaults)
+        project = select_project(client["id"], defaults)
+        { client: client, project: project }
+      end
+
+      def resolve_project_by_name(name, force: false)
+        projects = Spinner.spin("Fetching projects") { Api.fetch_projects(force: force) }
+        match = projects.find { |p| p["title"].downcase == name.downcase }
+        abort("Project not found: #{name}") unless match
+        match
+      end
+
+      def project_internal?(project)
+        project["internal"] || project["client_id"].nil?
+      end
+
+      def validate_internal_flag_usage!
+        abort("Cannot combine --client with --internal.") if options[:client] && options[:internal]
+        abort("--internal requires --project.") if options[:internal] && !options[:project]
+      end
+
+      def assert_internal_project_match!(project)
+        abort("Project #{project["title"]} is not internal.") if options[:internal] && !project_internal?(project)
+        if options[:client] && project_internal?(project)
+          abort("Cannot combine --client with internal project #{project["title"]}.")
+        end
+      end
+
+      def resolve_client_for_project(project, defaults)
+        clients = Spinner.spin("Fetching clients") { Api.fetch_clients }
+        match = clients.find { |c| c["id"].to_i == project["client_id"].to_i }
+        return match if match
+
+        default_client = clients.find { |c| c["id"].to_i == defaults["client_id"].to_i }
+        return default_client if default_client && default_client["id"].to_i == project["client_id"].to_i
+
+        abort("Client not found for project #{project["title"]}.")
+      end
+```
+
+- [ ] **Step 4: Re-run the targeted `log` specs and make them pass**
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/cli_spec.rb \
+  --example "non-interactive with --project on an internal project and no --client" \
+  --example "non-interactive with --internal and --client aborts" \
+  --example "non-interactive with --internal on a client-backed project aborts"
+```
+
+Expected: PASS for the new internal `log` coverage.
+
+- [ ] **Step 5: Commit the logging resolution work**
+
+Run:
+
+```bash
+git add lib/freshbooks/cli.rb spec/freshbooks/cli_spec.rb
+git commit -m "feat(log): support internal project resolution"
+```
+
+### Task 2: Write Failing Specs For Internal Editing Resolution
+
+**Files:**
+- Modify: `spec/freshbooks/cli_spec.rb`
+- Modify later: `lib/freshbooks/cli.rb`
+- Test: `spec/freshbooks/cli_spec.rb`
+
+- [ ] **Step 1: Add failing `edit` specs for moving entries onto internal projects**
+
+Add examples under `describe "edit"`:
+
+```ruby
+    context "scripted edit moves an entry to an internal project and omits client_id" do
+      Given {
+        stub_request(:get, %r{api\.freshbooks\.com/timetracking/business/12345/time_entries/42})
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "time_entry" => {
+                  "id" => 42,
+                  "duration" => 1800,
+                  "note" => "Tristan : Calum 1:1",
+                  "started_at" => "2026-04-21T00:00:00Z",
+                  "client_id" => 1084081,
+                  "project_id" => 12668685,
+                  "service_id" => 15770631,
+                  "is_logged" => true
+                }
+              }
+            }.to_json
+          )
+
+        FreshBooks::CLI::Auth.save_cache(
+          "updated_at" => Time.now.to_i - 60,
+          "clients" => { "1084081" => "CoinGecko" },
+          "projects" => { "12668685" => "Ad Platform & Token Listing", "12375603" => "AI Service Design" },
+          "services" => { "15770631" => "Meetings", "15770545" => "General" }
+        )
+
+        stub_request(:get, projects_url)
+          .with(query: hash_including("page" => 1, "per_page" => 100))
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "projects" => [
+                  {
+                    "id" => 12375603,
+                    "title" => "AI Service Design",
+                    "client_id" => nil,
+                    "internal" => true,
+                    "active" => true,
+                    "services" => [{ "id" => 15770631, "name" => "Meetings", "billable" => true }]
+                  }
+                ],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+
+        stub_request(:put, %r{api\.freshbooks\.com/timetracking/business/12345/time_entries/42})
+          .with { |req|
+            payload = JSON.parse(req.body)
+            entry = payload.fetch("time_entry")
+            entry["project_id"] == 12375603 &&
+              entry["service_id"] == 15770631 &&
+              !entry.key?("client_id")
+          }
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "result" => { "time_entry" => { "id" => 42 } } }.to_json
+          )
+      }
+      When(:output) {
+        capture_stdout {
+          FreshBooks::CLI::Commands.start([
+            "edit", "--id", "42", "--project", "AI Service Design",
+            "--service", "Meetings", "--yes", "--format", "json"
+          ])
+        }
+      }
+      Then { JSON.parse(output)["result"]["time_entry"]["id"] == 42 }
+      And  { assert_requested(:put, %r{api\.freshbooks\.com/timetracking/business/12345/time_entries/42}) }
+    end
+
+    context "scripted edit with --internal on a client-backed project aborts" do
+      Given {
+        stub_request(:get, %r{api\.freshbooks\.com/timetracking/business/12345/time_entries/42})
+          .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: {
+            "result" => { "time_entry" => { "id" => 42, "duration" => 1800, "note" => "test", "started_at" => "2026-04-21T00:00:00Z", "client_id" => 10, "project_id" => 20, "service_id" => 30, "is_logged" => true } }
+          }.to_json)
+      }
+      When(:result) {
+        invoke_cli_command(:edit, id: 42, project: "Client Project", internal: true, yes: true, no_interactive: true, stub_abort: true)
+      }
+      Then { result.is_a?(CliAbort) }
+    end
+```
+
+- [ ] **Step 2: Run the targeted `edit` specs and confirm they fail before implementation**
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/cli_spec.rb \
+  --example "scripted edit moves an entry to an internal project and omits client_id" \
+  --example "scripted edit with --internal on a client-backed project aborts"
+```
+
+Expected: FAIL because `build_edit_fields` currently preserves the old `client_id`.
+
+- [ ] **Step 3: Implement project-aware `edit` resolution**
+
+Update `edit`, `build_edit_fields`, and shared helpers in `lib/freshbooks/cli.rb`:
+
+```ruby
+      method_option :internal, type: :boolean, default: false, desc: "Move entry to an internal project with no client"
+      def edit
+        Auth.valid_access_token
+
+        entry_id = options[:id] || (abort("Missing required flag: --id") unless interactive?)
+        entry_id ||= pick_entry_interactive("edit")
+
+        entry = Spinner.spin("Fetching time entry") { Api.fetch_time_entry(entry_id) }
+        abort("Time entry not found.") unless entry
+
+        maps = Spinner.spin("Resolving names") { Api.build_name_maps }
+        has_edit_flags = options[:duration] || options[:note] || options[:date] || options[:client] || options[:project] || options[:service] || options[:internal]
+        scripted = has_edit_flags || !interactive?
+
+        fields = build_edit_fields(entry, maps, scripted)
+        current_project = maps[:projects][entry["project_id"].to_s] || "-"
+        current_hours = (entry["duration"].to_i / 3600.0).round(2)
+        new_hours = fields["duration"] ? (fields["duration"].to_i / 3600.0).round(2) : current_hours
+
+        unless options[:format] == "json"
+          puts "\n--- Edit Summary ---"
+          puts "  Date:     #{fields["started_at"] || entry["started_at"]}"
+          puts "  Client:   #{display_client_label_from_ids(fields["client_id"], fields["project_id"], maps)}"
+          puts "  Project:  #{fields["project_id"] ? maps[:projects][fields["project_id"].to_s] : current_project}"
+          puts "  Duration: #{new_hours}h"
+          puts "  Note:     #{fields["note"] || entry["note"]}"
+          puts "--------------------\n\n"
+        end
+
+        result = Spinner.spin("Updating time entry") { Api.update_time_entry(entry_id, fields.compact) }
+        puts(options[:format] == "json" ? JSON.pretty_generate(result) : "Time entry #{entry_id} updated.")
+      end
+
+      def build_edit_fields(entry, maps, scripted)
+        fields = {
+          "started_at" => entry["started_at"],
+          "is_logged" => entry["is_logged"] || true,
+          "duration" => entry["duration"],
+          "note" => entry["note"],
+          "client_id" => entry["client_id"],
+          "project_id" => entry["project_id"],
+          "service_id" => entry["service_id"]
+        }
+
+        return fields unless scripted
+
+        fields["duration"] = (options[:duration] * 3600).to_i if options[:duration]
+        fields["note"] = options[:note] if options[:note]
+        fields["started_at"] = normalize_datetime(options[:date]) if options[:date]
+
+        if options[:project]
+          project = resolve_project_by_name(options[:project], force: true)
+          assert_internal_project_match!(project)
+          fields["project_id"] = project["id"]
+          if project_internal?(project)
+            fields.delete("client_id")
+          else
+            fields["client_id"] = project["client_id"].to_i
+          end
+        elsif options[:client]
+          client_id = maps[:clients].find { |_id, name| name.downcase == options[:client].downcase }&.first
+          abort("Client not found: #{options[:client]}") unless client_id
+          fields["client_id"] = client_id.to_i
+        end
+
+        if options[:internal] && !options[:project]
+          abort("--internal requires --project.")
+        end
+
+        if options[:service]
+          service_id = maps[:services].find { |_id, name| name.downcase == options[:service].downcase }&.first
+          abort("Service not found: #{options[:service]}") unless service_id
+          fields["service_id"] = service_id.to_i
+        end
+
+        fields
+      end
+```
+
+- [ ] **Step 4: Re-run the targeted `edit` specs and make them pass**
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/cli_spec.rb \
+  --example "scripted edit moves an entry to an internal project and omits client_id" \
+  --example "scripted edit with --internal on a client-backed project aborts"
+```
+
+Expected: PASS for the new internal `edit` coverage.
+
+- [ ] **Step 5: Commit the editing resolution work**
+
+Run:
+
+```bash
+git add lib/freshbooks/cli.rb spec/freshbooks/cli_spec.rb
+git commit -m "feat(edit): support internal project moves"
+```
+
+### Task 3: Add Internal Display Support For Read Paths
+
+**Files:**
+- Modify: `spec/freshbooks/cli_spec.rb`
+- Modify later: `lib/freshbooks/cli.rb`
+- Test: `spec/freshbooks/cli_spec.rb`
+
+- [ ] **Step 1: Add failing specs for internal labels in `projects`, `entries`, and `status`**
+
+Add coverage that table output uses `Internal`:
+
+```ruby
+  describe "projects" do
+    context "table output shows Internal for internal projects" do
+      Given {
+        stub_request(:get, projects_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "projects" => [{ "id" => 12375603, "title" => "AI Service Design", "client_id" => nil, "internal" => true, "active" => true }],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+        FreshBooks::CLI::Auth.save_cache("updated_at" => Time.now.to_i - 60, "clients" => {}, "projects" => {}, "services" => {})
+      }
+      When(:output) { capture_stdout { FreshBooks::CLI::Commands.start(["projects"]) } }
+      Then { output.include?("AI Service Design") }
+      And  { output.include?("Internal") }
+    end
+  end
+
+  describe "entries" do
+    context "table output shows Internal for internal entries" do
+      Given {
+        stub_request(:get, time_entries_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "time_entries" => [
+                  { "id" => 42, "started_at" => "2026-04-13T00:00:00Z", "client_id" => nil, "project_id" => 12375603, "service_id" => 15770631, "note" => "Calum 1:1", "duration" => 1800 }
+                ],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+        FreshBooks::CLI::Auth.save_cache(
+          "updated_at" => Time.now.to_i - 60,
+          "clients" => {},
+          "projects" => { "12375603" => "AI Service Design" },
+          "services" => { "15770631" => "Meetings" }
+        )
+      }
+      When(:output) { capture_stdout { FreshBooks::CLI::Commands.start(["entries", "--from", "2026-04-13", "--to", "2026-04-13"]) } }
+      Then { output.include?("Internal") }
+    end
+  end
+```
+
+- [ ] **Step 2: Run the read-path specs and confirm they fail before implementation**
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/cli_spec.rb \
+  --example "table output shows Internal for internal projects" \
+  --example "table output shows Internal for internal entries"
+```
+
+Expected: FAIL because nil `client_id` currently renders as blank or `-`.
+
+- [ ] **Step 3: Add shared display helpers and update read paths**
+
+Add helpers in `lib/freshbooks/cli.rb` and use them in `entries`, `projects`, `status`, and `pick_entry_interactive`:
+
+```ruby
+      def display_client_label(client, project = nil)
+        return "Internal" if client.nil? && project && project_internal?(project)
+        return "Internal" if client.nil?
+        display_name(client)
+      end
+
+      def display_client_label_from_entry(entry, maps)
+        return "Internal" if entry["client_id"].nil?
+        maps[:clients][entry["client_id"].to_s] || entry["client_id"].to_s
+      end
+
+      def display_client_label_from_project(project, maps)
+        return "Internal" if project_internal?(project)
+        maps[:clients][project["client_id"].to_s] || "-"
+      end
+
+      def display_client_label_from_ids(client_id, project_id, maps)
+        return "Internal" if client_id.nil?
+        maps[:clients][client_id.to_s] || client_id.to_s
+      end
+```
+
+Update callers:
+
+```ruby
+          client = display_client_label_from_entry(e, maps)
+```
+
+```ruby
+        by_client = entries.group_by { |e| display_client_label_from_entry(e, maps) }
+```
+
+```ruby
+          client_name = display_client_label_from_project(p, maps)
+```
+
+```ruby
+          client = display_client_label_from_entry(e, maps)
+```
+
+- [ ] **Step 4: Re-run the read-path specs and make them pass**
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/cli_spec.rb \
+  --example "table output shows Internal for internal projects" \
+  --example "table output shows Internal for internal entries"
+```
+
+Expected: PASS for the new internal display coverage.
+
+- [ ] **Step 5: Commit the display support work**
+
+Run:
+
+```bash
+git add lib/freshbooks/cli.rb spec/freshbooks/cli_spec.rb
+git commit -m "feat(cli): label internal projects and entries"
+```
+
+### Task 4: Run The Full Relevant Test Slice
+
+**Files:**
+- Verify: `spec/freshbooks/cli_spec.rb`
+- Verify optionally: `spec/freshbooks/api_spec.rb`
+
+- [ ] **Step 1: Run the full CLI spec file after the focused changes**
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/cli_spec.rb
+```
+
+Expected: PASS for the full CLI suite.
+
+- [ ] **Step 2: If the CLI suite reveals cache or payload regressions, fix them immediately in the touched files**
+
+Likely fix shape if needed:
+
+```ruby
+        new_defaults = {}
+        new_defaults["client_id"] = context[:client]["id"] if context[:client]
+        new_defaults["project_id"] = project["id"] if project
+        new_defaults["service_id"] = service["id"] if service
+        Auth.save_defaults(new_defaults)
+```
+
+Run after each fix:
+
+```bash
+bundle exec rspec spec/freshbooks/cli_spec.rb
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit the test-green integration point**
+
+Run:
+
+```bash
+git add lib/freshbooks/cli.rb spec/freshbooks/cli_spec.rb
+git commit -m "test(cli): cover internal project client resolution"
+```
+
+### Task 5: Manual Live Verification Against The Calum 1:1 Entry
+
+**Files:**
+- Verify live FreshBooks data only
+- No automated fixture changes
+
+- [ ] **Step 1: Find the parked Calum 1:1 entry serially**
+
+Run:
+
+```bash
+bundle exec bin/fb entries --format json
+```
+
+Expected: find the entry whose note contains:
+
+```text
+Tristan : Calum 1:1 (parked here; AI Service Design not easily selectable via fb CLI for no-client projects)
+```
+
+- [ ] **Step 2: Move that live entry to the internal `AI Service Design` project**
+
+Run:
+
+```bash
+bundle exec bin/fb edit --id <entry-id> --project "AI Service Design" --service "Meetings" --yes --format json
+```
+
+Expected: JSON response showing the edited entry id. Run serially, not in parallel with other auth-backed commands.
+
+- [ ] **Step 3: Read the updated entry back and verify `client_id` is null**
+
+Run:
+
+```bash
+bundle exec bin/fb entries --format json
+```
+
+Expected: the edited record now shows:
+
+```json
+{
+  "id": <entry-id>,
+  "project_id": 12375603,
+  "client_id": null
+}
+```
+
+- [ ] **Step 4: Record the manual verification result in the final delivery notes**
+
+Capture these facts:
+
+```text
+- verified against live FreshBooks data
+- moved one Calum 1:1 entry onto AI Service Design
+- resulting entry read back with client_id: null
+```
+
+- [ ] **Step 5: Commit only repo changes, not live-data state**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only code/docs files are staged or modified; no extra files are created for the manual verification step.
+
+### Task 6: Update Help Text And All Related Documentation
+
+**Files:**
+- Modify: `lib/freshbooks/cli.rb`
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `skills/freshbooks/SKILL.md`
+
+- [ ] **Step 1: Update Thor option descriptions and help JSON in `lib/freshbooks/cli.rb`**
+
+Adjust help text so internal behavior is obvious:
+
+```ruby
+      method_option :internal, type: :boolean, default: false, desc: "Use an internal project and omit client_id"
+```
+
+Update `help_json` command docs to describe:
+
+```ruby
+                "--client" => "Client name (required only for client-backed project selection in non-interactive mode)",
+                "--project" => "Project name (can be internal; internal projects may be used without --client)",
+                "--internal" => "Force internal-project resolution; requires --project and conflicts with --client"
+```
+
+- [ ] **Step 2: Update `README.md` examples and behavior notes**
+
+Add or revise examples like:
+
+```bash
+fb log --project "AI Service Design" --service "Meetings" --duration 0.5 --note "Calum 1:1" --yes --format json
+fb log --internal --project "AI Service Design" --service "Meetings" --duration 0.5 --note "Calum 1:1" --yes --format json
+fb edit --id 12345 --project "AI Service Design" --service "Meetings" --yes --format json
+```
+
+Document:
+
+```text
+- Internal projects are detected from a fresh project lookup.
+- Internal project entries omit client_id.
+- Normal client-first logging still uses cached/default client behavior.
+- CLI table output shows Internal for internal projects and entries.
+```
+
+- [ ] **Step 3: Update `AGENTS.md` and `skills/freshbooks/SKILL.md`**
+
+Apply the same contract updates:
+
+```text
+- `fb log` does not require `--client` for internal projects.
+- `--internal` requires `--project` and conflicts with `--client`.
+- `fb edit` can move an entry onto an internal project and should end up with `client_id: null`.
+- Services remain project-scoped.
+```
+
+- [ ] **Step 4: Run the CLI help smoke checks**
+
+Run:
+
+```bash
+bundle exec bin/fb help log --format json
+bundle exec bin/fb help edit --format json
+```
+
+Expected: JSON output includes the updated option descriptions for `--project`, `--client`, and `--internal`.
+
+- [ ] **Step 5: Commit the docs and help updates**
+
+Run:
+
+```bash
+git add lib/freshbooks/cli.rb README.md AGENTS.md skills/freshbooks/SKILL.md
+git commit -m "docs(cli): document internal project workflows"
+```
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - `log` internal project support: Task 1
+  - `edit` internal project support: Task 2
+  - read/display support: Task 3
+  - manual Calum 1:1 verification: Task 5
+  - docs/help/skill updates: Task 6
+- Placeholder scan:
+  - no `TODO`, `TBD`, or “similar to above” shortcuts remain
+- Type consistency:
+  - helper names are consistent across the plan: `resolve_project_by_name`, `project_internal?`, `display_client_label_from_entry`

--- a/docs/plans/2026-04-21-internal-project-client-resolution-plan.md
+++ b/docs/plans/2026-04-21-internal-project-client-resolution-plan.md
@@ -1,7 +1,5 @@
 # Internal Project Client Resolution Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
-
 **Goal:** Allow `fb log` and `fb edit` to work correctly with internal FreshBooks projects, keep `client_id` omitted for internal project entries, and render internal records clearly in CLI output.
 
 **Architecture:** Keep the change narrow inside `FreshBooks::CLI::Commands` by adding a shared project/client resolution layer for `log` and `edit`, then reuse small display helpers for `entries`, `status`, `projects`, and interactive pickers. Preserve existing cached/default client behavior for normal flows while forcing a fresh project lookup only on internal or project-driven resolution paths.

--- a/lib/freshbooks/cli.rb
+++ b/lib/freshbooks/cli.rb
@@ -217,19 +217,21 @@ module FreshBooks
       method_option :duration, type: :numeric, desc: "Duration in hours (e.g. 2.5)"
       method_option :note, type: :string, desc: "Work description"
       method_option :date, type: :string, desc: "Date (YYYY-MM-DD, defaults to today)"
+      method_option :internal, type: :boolean, default: false, desc: "Log to an internal project with no client"
       method_option :yes, type: :boolean, default: false, desc: "Skip confirmation"
       def log
         Auth.valid_access_token
         defaults = Auth.load_defaults
 
-        client = select_client(defaults)
-        project = select_project(client["id"], defaults)
+        context = resolve_log_context(defaults)
+        client = context[:client]
+        project = context[:project]
         service = select_service(defaults, project)
         date = pick_date
         duration_hours = pick_duration
         note = pick_note
 
-        client_name = display_name(client)
+        client_name = client ? display_name(client) : "Internal"
 
         unless options[:format] == "json"
           puts "\n--- Time Entry Summary ---"
@@ -252,9 +254,9 @@ module FreshBooks
           "is_logged" => true,
           "duration" => (duration_hours * 3600).to_i,
           "note" => note,
-          "started_at" => normalize_datetime(date),
-          "client_id" => client["id"]
+          "started_at" => normalize_datetime(date)
         }
+        entry["client_id"] = client["id"] if client
         entry["project_id"] = project["id"] if project
         entry["service_id"] = service["id"] if service
 
@@ -266,7 +268,8 @@ module FreshBooks
           puts "Time entry created!"
         end
 
-        new_defaults = { "client_id" => client["id"] }
+        new_defaults = {}
+        new_defaults["client_id"] = client["id"] if client
         new_defaults["project_id"] = project["id"] if project
         new_defaults["service_id"] = service["id"] if service
         Auth.save_defaults(new_defaults)
@@ -328,7 +331,7 @@ module FreshBooks
 
         rows = entries.map do |e|
           date = (e["local_started_at"] || e["started_at"] || "?").slice(0, 10)
-          client = maps[:clients][e["client_id"].to_s] || e["client_id"].to_s
+          client = display_client_name(e["client_id"], maps)
           project = maps[:projects][e["project_id"].to_s] || "-"
           service = maps[:services][e["service_id"].to_s] || "-"
           note = e["note"] || ""
@@ -341,7 +344,7 @@ module FreshBooks
         total = entries.sum { |e| e["duration"].to_i } / 3600.0
 
         # Per-client breakdown
-        by_client = entries.group_by { |e| maps[:clients][e["client_id"].to_s] || e["client_id"].to_s }
+        by_client = entries.group_by { |e| display_client_name(e["client_id"], maps) }
         if by_client.length > 1
           puts "\nBy client:"
           by_client.sort_by { |_, es| -es.sum { |e| e["duration"].to_i } }.each do |name, es|
@@ -416,7 +419,7 @@ module FreshBooks
         end
 
         rows = projects.map do |p|
-          client_name = maps[:clients][p["client_id"].to_s] || "-"
+          client_name = display_project_client_name(p, maps)
           [p["title"], client_name, p["active"] ? "active" : "inactive"]
         end
 
@@ -520,6 +523,7 @@ module FreshBooks
       method_option :client, type: :string, desc: "New client name"
       method_option :project, type: :string, desc: "New project name"
       method_option :service, type: :string, desc: "New service name"
+      method_option :internal, type: :boolean, default: false, desc: "Move entry to an internal project with no client"
       method_option :yes, type: :boolean, default: false, desc: "Skip confirmation"
       def edit
         Auth.valid_access_token
@@ -535,7 +539,7 @@ module FreshBooks
         abort("Time entry not found.") unless entry
 
         maps = Spinner.spin("Resolving names") { Api.build_name_maps }
-        has_edit_flags = options[:duration] || options[:note] || options[:date] || options[:client] || options[:project] || options[:service]
+        has_edit_flags = options[:duration] || options[:note] || options[:date] || options[:client] || options[:project] || options[:service] || options[:internal]
         scripted = has_edit_flags || !interactive?
 
         fields = build_edit_fields(entry, maps, scripted)
@@ -544,11 +548,18 @@ module FreshBooks
         current_project = maps[:projects][entry["project_id"].to_s] || "-"
         current_hours = (entry["duration"].to_i / 3600.0).round(2)
         new_hours = fields["duration"] ? (fields["duration"].to_i / 3600.0).round(2) : current_hours
+        summary_client = if fields.key?("client_id")
+          fields["client_id"] ? maps[:clients][fields["client_id"].to_s] : "Internal"
+        elsif fields["project_id"] != entry["project_id"]
+          "Internal"
+        else
+          current_client
+        end
 
         unless options[:format] == "json"
           puts "\n--- Edit Summary ---"
           puts "  Date:     #{fields["started_at"] || entry["started_at"]}"
-          puts "  Client:   #{fields["client_id"] ? maps[:clients][fields["client_id"].to_s] : current_client}"
+          puts "  Client:   #{summary_client}"
           puts "  Project:  #{fields["project_id"] ? maps[:projects][fields["project_id"].to_s] : current_project}"
           puts "  Duration: #{new_hours}h"
           puts "  Note:     #{fields["note"] || entry["note"]}"
@@ -644,6 +655,63 @@ module FreshBooks
         return false if options[:no_interactive]
         return true if options[:interactive]
         $stdin.tty?
+      end
+
+      def resolve_log_context(defaults)
+        validate_internal_log_options!
+
+        if options[:project] && (!options[:client] || options[:internal])
+          project = resolve_project_by_name(options[:project], force: true)
+          ensure_project_matches_internal_option!(project)
+          client = project_internal?(project) ? nil : resolve_client_for_project(project)
+          return { client: client, project: project }
+        end
+
+        client = select_client(defaults)
+        project = select_project(client["id"], defaults)
+        { client: client, project: project }
+      end
+
+      def validate_internal_log_options!
+        abort("Cannot combine --client with --internal.") if options[:client] && options[:internal]
+        abort("--internal requires --project.") if options[:internal] && !options[:project]
+      end
+
+      def validate_internal_edit_options!
+        abort("Cannot combine --client with --internal.") if options[:client] && options[:internal]
+        abort("--internal requires --project.") if options[:internal] && !options[:project]
+      end
+
+      def resolve_project_by_name(name, force: false)
+        projects = Spinner.spin("Fetching projects") { Api.fetch_projects(force: force) }
+        match = projects.find { |project| project["title"].downcase == name.downcase }
+        abort("Project not found: #{name}") unless match
+        match
+      end
+
+      def project_internal?(project)
+        project["internal"] || project["client_id"].nil?
+      end
+
+      def display_client_name(client_id, maps)
+        return "Internal" if client_id.nil?
+        maps[:clients][client_id.to_s] || client_id.to_s
+      end
+
+      def display_project_client_name(project, maps)
+        return "Internal" if project_internal?(project)
+        maps[:clients][project["client_id"].to_s] || "-"
+      end
+
+      def ensure_project_matches_internal_option!(project)
+        abort("Project #{project["title"]} is not internal.") if options[:internal] && !project_internal?(project)
+      end
+
+      def resolve_client_for_project(project)
+        clients = Spinner.spin("Fetching clients") { Api.fetch_clients }
+        match = clients.find { |client| client["id"].to_i == project["client_id"].to_i }
+        abort("Client not found for project: #{project["title"]}") unless match
+        match
       end
 
       def select_client(defaults)
@@ -865,7 +933,7 @@ module FreshBooks
 
         grouped = {}
         entries.each do |e|
-          client = maps[:clients][e["client_id"].to_s] || e["client_id"].to_s
+          client = display_client_name(e["client_id"], maps)
           project = maps[:projects][e["project_id"].to_s] || "-"
           key = "#{client} / #{project}"
           grouped[key] ||= 0.0
@@ -884,7 +952,7 @@ module FreshBooks
         entry_data = entries.map do |e|
           {
             "id" => e["id"],
-            "client" => maps[:clients][e["client_id"].to_s] || e["client_id"].to_s,
+            "client" => display_client_name(e["client_id"], maps),
             "project" => maps[:projects][e["project_id"].to_s] || "-",
             "duration" => e["duration"],
             "hours" => (e["duration"].to_i / 3600.0).round(2),
@@ -907,7 +975,7 @@ module FreshBooks
 
         puts "\nToday's entries:\n\n"
         entries.each_with_index do |e, i|
-          client = maps[:clients][e["client_id"].to_s] || e["client_id"].to_s
+          client = display_client_name(e["client_id"], maps)
           hours = (e["duration"].to_i / 3600.0).round(2)
           note = (e["note"] || "").slice(0, 40)
           puts "  #{i + 1}. [#{e["id"]}] #{client} — #{hours}h — #{note}"
@@ -935,20 +1003,24 @@ module FreshBooks
         }
 
         if scripted
+          validate_internal_edit_options!
           fields["duration"] = (options[:duration] * 3600).to_i if options[:duration]
           fields["note"] = options[:note] if options[:note]
           fields["started_at"] = normalize_datetime(options[:date]) if options[:date]
 
-          if options[:client]
+          if options[:project]
+            project = resolve_project_by_name(options[:project], force: true)
+            ensure_project_matches_internal_option!(project)
+            fields["project_id"] = project["id"]
+            if project_internal?(project)
+              fields.delete("client_id")
+            else
+              fields["client_id"] = project["client_id"].to_i
+            end
+          elsif options[:client]
             client_id = maps[:clients].find { |_id, name| name.downcase == options[:client].downcase }&.first
             abort("Client not found: #{options[:client]}") unless client_id
             fields["client_id"] = client_id.to_i
-          end
-
-          if options[:project]
-            project_id = maps[:projects].find { |_id, name| name.downcase == options[:project].downcase }&.first
-            abort("Project not found: #{options[:project]}") unless project_id
-            fields["project_id"] = project_id.to_i
           end
 
           if options[:service]
@@ -1023,12 +1095,13 @@ module FreshBooks
               usage: "fb log",
               interactive: "Prompts for missing fields when interactive; requires --duration and --note when non-interactive",
               flags: {
-                "--client" => "Client name (required non-interactive if multiple clients, auto-selected if single)",
-                "--project" => "Project name (optional, auto-selected if single)",
-                "--service" => "Service name (optional)",
+                "--client" => "Client name (required only for client-backed resolution when multiple clients exist)",
+                "--project" => "Project name (can be internal; internal projects may be used without --client)",
+                "--service" => "Service name (project-scoped; optional if single/default)",
                 "--duration" => "Duration in hours, e.g. 2.5 (required non-interactive)",
                 "--note" => "Work description (required non-interactive)",
                 "--date" => "Date YYYY-MM-DD (defaults to today)",
+                "--internal" => "Force internal-project resolution; requires --project and conflicts with --client",
                 "--yes" => "Skip confirmation prompt"
               }
             },
@@ -1080,8 +1153,9 @@ module FreshBooks
                 "--note" => "New note",
                 "--date" => "New date (YYYY-MM-DD)",
                 "--client" => "New client name",
-                "--project" => "New project name",
+                "--project" => "New project name (internal projects omit client_id)",
                 "--service" => "New service name",
+                "--internal" => "Force internal-project resolution; requires --project and conflicts with --client",
                 "--yes" => "Skip confirmation prompt"
               }
             },

--- a/skills/freshbooks/SKILL.md
+++ b/skills/freshbooks/SKILL.md
@@ -78,10 +78,11 @@ Use `fb auth status --format json` and branch exactly once per blocker:
 
 - Before logging, resolve resources in this order:
   1. `fb clients --format json`
-  2. `fb projects --client "Name" --format json`
+  2. `fb projects --client "Name" --format json` for client-backed work, or `fb projects --format json` when the target may be internal
 - Services are project-scoped. Always resolve service from the selected project's `services` array.
 - Never depend on `fb services` alone for logging decisions.
-- If multiple clients exist and user did not specify one, ask once for client name.
+- Internal projects may be used without `--client`. If `project.internal` is true or `project.client_id` is null, treat the entry as clientless.
+- If multiple clients exist and the target is client-backed and user did not specify one, ask once for client name.
 - If project is ambiguous, ask once for project name.
 - If service cannot be inferred from user intent, ask once for service name.
 
@@ -121,8 +122,12 @@ fb entries --from YYYY-MM-DD --to YYYY-MM-DD --format json  # Date range
 ### Log Time
 ```bash
 fb log --client "Client Name" --project "Project" --service "Service" --duration HOURS --note "Description" --yes --format json
+fb log --project "AI Service Design" --service "Meetings" --duration 0.5 --note "Calum 1:1" --yes --format json
+fb log --internal --project "AI Service Design" --service "Meetings" --duration 0.5 --note "Calum 1:1" --yes --format json
 # --project is required when multiple projects are possible and should be supplied for deterministic automation.
-# --date is optional; --client, --duration, --note, and --service are required.
+# --date is optional; --duration, --note, and --service are required.
+# --client is required only for client-backed project resolution when the project does not determine the client.
+# --internal requires --project and conflicts with --client.
 # IMPORTANT: Always include --service. Infer the service from context (e.g. "development work" → "Development",
 # "meeting" → "Meetings", "research" → "Research"). If unsure, ask the user. Never omit --service.
 ```
@@ -132,6 +137,8 @@ fb log --client "Client Name" --project "Project" --service "Service" --duration
 fb edit --id ENTRY_ID --duration HOURS --yes --format json
 fb edit --id ENTRY_ID --note "New note" --yes --format json
 fb edit --id ENTRY_ID --service "Meetings" --yes --format json
+fb edit --id ENTRY_ID --project "AI Service Design" --service "Meetings" --yes --format json
+fb edit --id ENTRY_ID --internal --project "AI Service Design" --service "Meetings" --yes --format json
 # Edit preserves all existing fields — only specified flags are changed
 ```
 
@@ -143,7 +150,7 @@ fb delete --id ENTRY_ID --yes --format json
 ### List Resources
 ```bash
 fb clients --format json
-fb projects --format json                   # Includes project-scoped services in response
+fb projects --format json                   # Includes project-scoped services in response; internal projects show "internal": true
 fb projects --client "Name" --format json   # Filter by client; services array shows available services
 fb business --format json
 ```
@@ -176,9 +183,11 @@ fb cache refresh                # Force refresh
 - `Could not find 'code' parameter`:
   - Ask user to paste full redirect URL including query string.
 - `Multiple clients found. Use --client`:
-  - Ask once for client name, then continue.
+  - Ask once for client name, unless the chosen project is internal.
 - `Multiple projects found. Use --project`:
   - Ask once for project name, then continue.
+- `Project <name> is not internal`:
+  - Remove `--internal` or choose an actual internal project.
 - `Service not found`:
   - Refresh project list for selected client and pick service from that project.
 - Missing required flags in non-interactive mode:

--- a/spec/freshbooks/cli_spec.rb
+++ b/spec/freshbooks/cli_spec.rb
@@ -272,6 +272,25 @@ RSpec.describe FreshBooks::CLI::Commands do
       Then { output.include?("Website Redesign") }
       And  { !output.include?("Other Project") }
     end
+
+    context "table output shows Internal for internal projects" do
+      Given {
+        stub_request(:get, projects_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "projects" => [{ "id" => 12375603, "title" => "AI Service Design", "client_id" => nil, "internal" => true, "active" => true }],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+      }
+      When(:output) { capture_stdout { FreshBooks::CLI::Commands.start(["projects"]) } }
+      Then { output.include?("AI Service Design") }
+      And  { output.include?("Internal") }
+    end
   end
 
   # --- services ---
@@ -392,6 +411,51 @@ RSpec.describe FreshBooks::CLI::Commands do
           json["today"]["total_hours"] == 1.0 &&
           json["today"]["entries"].first["client"] == "Acme Corp"
       }
+    end
+
+    context "with internal entries" do
+      Given {
+        today = Date.today.to_s
+        stub_request(:get, time_entries_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "time_entries" => [
+                  { "id" => 1, "client_id" => nil, "project_id" => 12375603, "duration" => 3600, "started_at" => today, "note" => "Calum 1:1" }
+                ],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+        stub_request(:get, clients_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "result" => { "clients" => [], "meta" => { "pages" => 1, "page" => 1 } } }.to_json
+          )
+        stub_request(:get, projects_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "projects" => [{ "id" => 12375603, "title" => "AI Service Design", "client_id" => nil, "internal" => true, "active" => true }],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+        stub_request(:get, services_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "result" => { "services" => {} } }.to_json
+          )
+      }
+      When(:output) { capture_stdout { FreshBooks::CLI::Commands.start(["status"]) } }
+      Then { output.include?("Internal / AI Service Design") }
+      And  { output.include?("1.0h") }
     end
   end
 
@@ -525,6 +589,127 @@ RSpec.describe FreshBooks::CLI::Commands do
       When(:result) { invoke_cli_command(:edit, no_interactive: false, stub_abort: true) }
       Then { result.is_a?(CliAbort) }
     end
+
+    context "scripted edit moves an entry to an internal project and omits client_id" do
+      Given {
+        stub_request(:get, entry_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "time_entry" => {
+                  "id" => 999,
+                  "duration" => 1800,
+                  "note" => "Tristan : Calum 1:1",
+                  "started_at" => "2026-04-21T00:00:00Z",
+                  "client_id" => 1084081,
+                  "project_id" => 12668685,
+                  "service_id" => 15770631,
+                  "is_logged" => true
+                }
+              }
+            }.to_json
+          )
+        stub_request(:get, clients_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "clients" => [{ "id" => 1084081, "organization" => "CoinGecko", "fname" => "C", "lname" => "G" }],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+        stub_request(:get, projects_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "projects" => [
+                  { "id" => 12668685, "title" => "Ad Platform & Token Listing", "client_id" => 1084081, "internal" => false, "active" => true },
+                  {
+                    "id" => 12375603,
+                    "title" => "AI Service Design",
+                    "client_id" => nil,
+                    "internal" => true,
+                    "active" => true,
+                    "services" => [{ "id" => 15770631, "name" => "Meetings", "billable" => true }]
+                  }
+                ],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+        stub_request(:get, services_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "result" => { "services" => {} } }.to_json
+          )
+        stub_request(:put, entry_url)
+          .with { |req|
+            payload = JSON.parse(req.body)
+            entry = payload.fetch("time_entry")
+            entry["project_id"] == 12375603 &&
+              entry["service_id"] == 15770631 &&
+              !entry.key?("client_id")
+          }
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "time_entry" => { "id" => 999, "project_id" => 12375603, "service_id" => 15770631 }
+              }
+            }.to_json
+          )
+      }
+      When(:result) {
+        begin
+          capture_stdout {
+            FreshBooks::CLI::Commands.start([
+              "edit", "--id", "999", "--project", "AI Service Design",
+              "--service", "Meetings", "--yes", "--format", "json"
+            ])
+          }
+        rescue StandardError => e
+          e
+        end
+      }
+      Then { result.is_a?(String) && JSON.parse(result).dig("result", "time_entry", "id") == 999 }
+    end
+
+    context "scripted edit with --internal on a client-backed project aborts" do
+      Given {
+        stub_edit_apis
+        stub_request(:get, projects_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "projects" => [{ "id" => 20, "title" => "Website", "client_id" => 10, "internal" => false, "active" => true }],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+      }
+      When(:result) {
+        invoke_cli_command(
+          :edit,
+          id: 999,
+          project: "Website",
+          internal: true,
+          yes: true,
+          no_interactive: true,
+          stub_abort: true
+        )
+      }
+      Then { result.is_a?(CliAbort) }
+    end
   end
 
   # --- log ---
@@ -654,6 +839,164 @@ RSpec.describe FreshBooks::CLI::Commands do
       }
       When(:result) {
         invoke_cli_command(:log, duration: 2.5, note: "test", yes: true, no_interactive: false, stub_abort: true)
+      }
+      Then { result.is_a?(CliAbort) }
+    end
+
+    context "non-interactive with --project on an internal project and no --client" do
+      Given {
+        allow($stdin).to receive(:tty?).and_return(false)
+
+        stub_request(:get, clients_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "clients" => [
+                  { "id" => 10, "organization" => "Acme Corp", "fname" => "J", "lname" => "D" },
+                  { "id" => 11, "organization" => "Globex Inc", "fname" => "G", "lname" => "X" }
+                ],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+
+        stub_request(:get, projects_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "projects" => [
+                  {
+                    "id" => 12375603,
+                    "title" => "AI Service Design",
+                    "client_id" => nil,
+                    "internal" => true,
+                    "active" => true,
+                    "services" => [{ "id" => 15770631, "name" => "Meetings", "billable" => true }]
+                  }
+                ],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+
+        stub_request(:post, time_entries_url)
+          .with { |req|
+            payload = JSON.parse(req.body)
+            entry = payload.fetch("time_entry")
+            entry["project_id"] == 12375603 &&
+              entry["service_id"] == 15770631 &&
+              !entry.key?("client_id")
+          }
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "time_entry" => { "id" => 777, "project_id" => 12375603, "service_id" => 15770631 }
+              }
+            }.to_json
+          )
+      }
+      When(:result) {
+        begin
+          capture_stdout {
+            FreshBooks::CLI::Commands.start([
+              "log", "--project", "AI Service Design", "--service", "Meetings",
+              "--duration", "0.5", "--note", "Calum 1:1", "--yes", "--format", "json"
+            ])
+          }
+        rescue SystemExit => e
+          e
+        end
+      }
+      Then { result.is_a?(String) && JSON.parse(result).dig("result", "time_entry", "id") == 777 }
+    end
+
+    context "non-interactive with --internal and --client aborts" do
+      Given {
+        allow($stdin).to receive(:tty?).and_return(false)
+        stub_log_apis
+      }
+      When(:result) {
+        invoke_cli_command(
+          :log,
+          client: "Acme Corp",
+          duration: 0.5,
+          note: "Calum 1:1",
+          yes: true,
+          internal: true,
+          no_interactive: false,
+          stub_abort: true
+        )
+      }
+      Then { result.is_a?(CliAbort) }
+    end
+
+    context "non-interactive with --internal on a client-backed project aborts" do
+      Given {
+        allow($stdin).to receive(:tty?).and_return(false)
+        stub_request(:get, clients_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "clients" => [{ "id" => 10, "organization" => "Acme Corp", "fname" => "J", "lname" => "D" }],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+        stub_request(:get, projects_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "projects" => [
+                  {
+                    "id" => 20,
+                    "title" => "Client Project",
+                    "client_id" => 10,
+                    "internal" => false,
+                    "active" => true
+                  }
+                ],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+        stub_request(:get, services_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "result" => { "services" => {} } }.to_json
+          )
+        stub_request(:post, time_entries_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "time_entry" => { "id" => 555, "duration" => 1800, "note" => "Calum 1:1" }
+              }
+            }.to_json
+          )
+      }
+      When(:result) {
+        invoke_cli_command(
+          :log,
+          project: "Client Project",
+          duration: 0.5,
+          note: "Calum 1:1",
+          yes: true,
+          internal: true,
+          no_interactive: false,
+          stub_abort: true
+        )
       }
       Then { result.is_a?(CliAbort) }
     end
@@ -894,6 +1237,53 @@ RSpec.describe FreshBooks::CLI::Commands do
       }
       Then { output.include?("ID") }
       And  { output.include?("42") }
+    end
+
+    context "table output shows Internal for internal entries" do
+      Given {
+        stub_request(:get, time_entries_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "time_entries" => [
+                  { "id" => 42, "client_id" => nil, "project_id" => 12375603, "duration" => 3600,
+                    "started_at" => "2024-03-01", "note" => "Calum 1:1" }
+                ],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+        stub_request(:get, clients_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "result" => { "clients" => [], "meta" => { "pages" => 1, "page" => 1 } } }.to_json
+          )
+        stub_request(:get, projects_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "result" => {
+                "projects" => [{ "id" => 12375603, "title" => "AI Service Design", "client_id" => nil, "internal" => true }],
+                "meta" => { "pages" => 1, "page" => 1 }
+              }
+            }.to_json
+          )
+        stub_request(:get, services_url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "result" => { "services" => {} } }.to_json
+          )
+      }
+      When(:output) {
+        capture_stdout { FreshBooks::CLI::Commands.start(["entries", "--from", "2024-03-01", "--to", "2024-03-31"]) }
+      }
+      Then { output.include?("Internal") }
+      And  { output.include?("AI Service Design") }
     end
   end
 


### PR DESCRIPTION
## Summary
- support logging and editing time entries against internal FreshBooks projects without requiring a client
- omit `client_id` for internal project payloads and render internal records clearly in CLI output
- update help text, README, AGENTS guidance, and the repo FreshBooks skill for the new workflow

## Root Cause
The CLI resolved clients before projects and always sent `client_id`, which broke internal projects where FreshBooks returns `client_id: null`.

## Test Plan
- [x] `bundle exec rspec spec/freshbooks/cli_spec.rb`
- [x] `bundle exec bin/fb help log --format json`
- [x] `bundle exec bin/fb help edit --format json`
- [x] Manual verification against an existing entry moved onto an internal project and read back with `client_id: null`
