### PR TITLE
fix(auth): serialize token refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ rspec
 
 The gem is a CLI (`FreshBooks::CLI`) built on Thor, with four components:
 
-- **Auth** (`lib/freshbooks/auth.rb`) — OAuth2 flow, token management, config/cache/defaults persistence. All state stored as JSON files in `FreshBooks::CLI::Auth.data_dir` (see resolution order below). Tests redirect this to a tmpdir. Provides both interactive (`setup_config`, `authorize`, `discover_business`) and non-interactive (`setup_config_from_args`, `authorize_url`, `extract_code_from_url`, `exchange_code`, `fetch_businesses`, `select_business`, `auth_status`) methods.
+- **Auth** (`lib/freshbooks/auth.rb`) — OAuth2 flow, token management, config/cache/defaults persistence. All state stored as JSON files in `FreshBooks::CLI::Auth.data_dir` (see resolution order below). Token writes are atomic, and token refresh uses a sibling lock file to serialize concurrent refreshes and re-read freshly written tokens. Tests redirect this to a tmpdir. Provides both interactive (`setup_config`, `authorize`, `discover_business`) and non-interactive (`setup_config_from_args`, `authorize_url`, `extract_code_from_url`, `exchange_code`, `fetch_businesses`, `select_business`, `auth_status`) methods.
 - **Api** (`lib/freshbooks/api.rb`) — FreshBooks REST client. All HTTP goes through HTTParty. Paginated fetching via `fetch_all_pages`. Name maps (client/project/service ID → name) cached for 10 minutes in `cache.json`. Services are project-scoped — `build_name_maps` extracts them from project data, not just the global services endpoint.
 - **Commands** (`lib/freshbooks/cli.rb`) — Thor subclass (`FreshBooks::CLI::Commands`). Commands: `auth`, `business`, `log`, `entries`, `clients`, `projects`, `services`, `status`, `edit`, `delete`, `cache`, `help`, `version`. Interactive prompts read from `$stdin`. Interactive detection via `$stdin.tty?` + `--no-interactive` flag.
 - **Spinner** (`lib/freshbooks/spinner.rb`) — Braille animation spinner. Yields to a block, returns block result. Globally stubbed in tests to just yield.
@@ -106,7 +106,7 @@ All commands support `--format json` (global class option). Mutation commands (`
 ## Key Patterns
 
 - All modules use `class << self` (singleton methods only, no instances)
-- Config, tokens, defaults, cache are all separate JSON files under `FreshBooks::CLI::Auth.data_dir`
+- Config, tokens, defaults, cache are all separate JSON files under `FreshBooks::CLI::Auth.data_dir`; token refresh coordination uses `tokens.json.lock`
 - `FreshBooks::CLI::Auth.data_dir=` is the seam for test isolation — point it at a tmpdir; set to `nil` to reset to auto-resolution. Resolution order: `FRESHBOOKS_HOME` env var → `~/.fb` (legacy) → platform-native default (macOS: `~/Library/Application Support/freshbooks`; Linux: `~/.config/freshbooks`)
 - Docker wrapper (`./fb`) runs CLI in container with the data directory bind-mounted and host `TZ` passed through
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ fb auth status                 # human-readable
 fb auth status --format json   # structured output
 ```
 
-Tokens auto-refresh before every API call — no need to re-auth unless you revoke app access.
+Tokens auto-refresh before every API call — no need to re-auth unless you revoke app access. Refresh is serialized across concurrent `fb` processes so parallel commands can reuse the newly written token.
 
 ### `fb business`
 

--- a/lib/freshbooks/auth.rb
+++ b/lib/freshbooks/auth.rb
@@ -60,6 +60,10 @@ module FreshBooks
           File.join(data_dir, "tokens.json")
         end
 
+        def tokens_lock_path
+          File.join(data_dir, "tokens.json.lock")
+        end
+
         def defaults_path
           File.join(data_dir, "defaults.json")
         end
@@ -258,7 +262,15 @@ module FreshBooks
 
         def save_tokens(tokens)
           ensure_data_dir
-          File.write(tokens_path, JSON.pretty_generate(tokens) + "\n")
+          tmp_path = "#{tokens_path}.#{$$}.tmp"
+          File.open(tmp_path, File::WRONLY | File::CREAT | File::TRUNC, 0o600) do |file|
+            file.write(JSON.pretty_generate(tokens) + "\n")
+            file.flush
+            file.fsync
+          end
+          File.rename(tmp_path, tokens_path)
+        ensure
+          File.delete(tmp_path) if tmp_path && File.exist?(tmp_path)
         end
 
         def token_expired?(tokens)
@@ -297,6 +309,20 @@ module FreshBooks
           new_tokens
         end
 
+        def refresh_token_with_lock(config, tokens)
+          ensure_data_dir
+          File.open(tokens_lock_path, File::RDWR | File::CREAT, 0o600) do |lock_file|
+            lock_file.flock(File::LOCK_EX)
+
+            latest_tokens = load_tokens || tokens
+            return latest_tokens if latest_tokens && !token_expired?(latest_tokens)
+
+            refresh_token!(config, latest_tokens || tokens)
+          ensure
+            lock_file.flock(File::LOCK_UN)
+          end
+        end
+
         def valid_access_token
           if Thread.current[:fb_dry_run]
             tokens = load_tokens
@@ -315,7 +341,7 @@ module FreshBooks
 
           if token_expired?(tokens)
             puts "Token expired, refreshing..."
-            tokens = refresh_token!(config, tokens)
+            tokens = refresh_token_with_lock(config, tokens)
           end
 
           tokens["access_token"]

--- a/spec/freshbooks/auth_spec.rb
+++ b/spec/freshbooks/auth_spec.rb
@@ -118,6 +118,110 @@ RSpec.describe FreshBooks::CLI::Auth do
     end
   end
 
+  describe ".save_tokens" do
+    context "when replacing an existing token file fails at rename" do
+      Given(:original_tokens) {
+        {
+          "access_token" => "old_access",
+          "refresh_token" => "old_refresh",
+          "expires_in" => 3600,
+          "created_at" => Time.now.to_i
+        }
+      }
+
+      Given {
+        FreshBooks::CLI::Auth.save_tokens(original_tokens)
+        allow(File).to receive(:rename).and_call_original
+        allow(File).to receive(:rename).with(/tokens\.json\./, FreshBooks::CLI::Auth.tokens_path).and_raise(Errno::EACCES)
+      }
+
+      When(:result) {
+        begin
+          FreshBooks::CLI::Auth.save_tokens(
+            "access_token" => "new_access",
+            "refresh_token" => "new_refresh",
+            "expires_in" => 3600,
+            "created_at" => Time.now.to_i
+          )
+        rescue Errno::EACCES => e
+          e
+        end
+      }
+
+      Then { result.is_a?(Errno::EACCES) }
+      And  { FreshBooks::CLI::Auth.load_tokens == original_tokens }
+    end
+  end
+
+  describe ".valid_access_token with expired tokens" do
+    Given(:config) { { "client_id" => "cid", "client_secret" => "csec" } }
+
+    Given {
+      allow(FreshBooks::CLI::Auth).to receive(:require_config).and_return(config)
+    }
+
+    context "when another process refreshed tokens before the lock is acquired" do
+      Given {
+        FreshBooks::CLI::Auth.save_tokens(
+          "access_token" => "old_access",
+          "refresh_token" => "old_refresh",
+          "expires_in" => 3600,
+          "created_at" => Time.now.to_i - 7200
+        )
+
+        allow(FreshBooks::CLI::Auth).to receive(:token_expired?).and_wrap_original do |original, tokens|
+          if tokens && tokens["access_token"] == "old_access"
+            FreshBooks::CLI::Auth.save_tokens(
+              "access_token" => "fresh_access",
+              "refresh_token" => "fresh_refresh",
+              "expires_in" => 3600,
+              "created_at" => Time.now.to_i
+            )
+          end
+          original.call(tokens)
+        end
+
+        stub_request(:post, FreshBooks::CLI::Auth::TOKEN_URL)
+      }
+
+      When(:result) { FreshBooks::CLI::Auth.valid_access_token }
+      Then { result == "fresh_access" }
+      And  {
+        assert_not_requested(:post, FreshBooks::CLI::Auth::TOKEN_URL)
+        true
+      }
+    end
+
+    context "when tokens are still expired inside the lock" do
+      Given {
+        FreshBooks::CLI::Auth.save_tokens(
+          "access_token" => "old_access",
+          "refresh_token" => "old_refresh",
+          "expires_in" => 3600,
+          "created_at" => Time.now.to_i - 7200
+        )
+
+        stub_request(:post, FreshBooks::CLI::Auth::TOKEN_URL)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "access_token" => "new_access",
+              "refresh_token" => "new_refresh",
+              "expires_in" => 3600
+            }.to_json
+          )
+      }
+
+      When(:result) { FreshBooks::CLI::Auth.valid_access_token }
+      Then { result == "new_access" }
+      And  {
+        assert_requested(:post, FreshBooks::CLI::Auth::TOKEN_URL, times: 1)
+        true
+      }
+    end
+  end
+
   # --- Scope Checking ---
 
   describe ".check_scopes" do


### PR DESCRIPTION
## Summary

- serialize expired token refresh with a sibling lock file
- re-read tokens inside the lock so parallel commands can reuse a freshly written token
- write tokens atomically via temp file + rename to avoid partial JSON reads
- document concurrent refresh behavior

## Tests

- bundle exec rspec spec/freshbooks/auth_spec.rb
- bundle exec rspec
