### PR TITLE
fix(api): allow dry-run read lookups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,12 +80,12 @@ The `data_dir=` setter still works for test isolation — point it at a tmpdir. 
 All commands support `--dry-run` (global class option). When set:
 
 - Auth is partially bypassed — `valid_access_token` returns the stored access token if one exists and is not expired; falls back to `"dry-run-token"` when unauthenticated. `require_config` reads config.json directly without requiring credentials
-- Most read API calls use cached data ignoring freshness (stale cache is acceptable); if cache is empty, reads return `[]`. Single-entry reads (`fetch_time_entry`) make a real API call using the available token, so `edit --dry-run` shows actual entry data when authenticated
+- Read API calls may still hit FreshBooks so name resolution and previews match real commands. Cached data can still be used where normal command paths use cache.
 - Write API calls (`create_time_entry`, `update_time_entry`, `delete_time_entry`) return mock responses without hitting the network
 - A `[DRY RUN] No changes will be made.` banner is printed to stderr before the command runs
 - With `--format json`, all output is wrapped with `"_dry_run": {"simulated": true}` metadata; array results are nested under `"data"`
 
-Implementation uses `Thread.current[:fb_dry_run]` set in `invoke_command` with `ensure` cleanup (intentionally unchanged internal detail — not tied to the module namespace). Dry-run guards are added as the first line of ~8 leaf methods in `FreshBooks::CLI::Auth` and `FreshBooks::CLI::Api`. All business logic (name map building, pagination, caching) runs unchanged through the same code paths.
+Implementation uses `Thread.current[:fb_dry_run]` set in `invoke_command` with `ensure` cleanup (intentionally unchanged internal detail — not tied to the module namespace). Dry-run guards are limited to auth bypass and write leaf methods in `FreshBooks::CLI::Auth` and `FreshBooks::CLI::Api`. All business logic (name map building, pagination, caching) runs unchanged through the same code paths.
 
 ### JSON Output
 

--- a/lib/freshbooks/api.rb
+++ b/lib/freshbooks/api.rb
@@ -41,8 +41,6 @@ module FreshBooks
         # --- Paginated fetch ---
 
         def fetch_all_pages(url, result_key, params: {})
-          return [] if Thread.current[:fb_dry_run]
-
           page = 1
           all_items = []
 
@@ -132,8 +130,6 @@ module FreshBooks
         # --- Services ---
 
         def fetch_services(force: false)
-          return (Auth.load_cache["services_data"] || []) if Thread.current[:fb_dry_run]
-
           unless force
             cached = cached_data("services_data")
             return cached if cached

--- a/lib/freshbooks/cli.rb
+++ b/lib/freshbooks/cli.rb
@@ -16,7 +16,7 @@ module FreshBooks
       class_option :no_interactive, type: :boolean, default: false, desc: "Disable interactive prompts (auto-detected when not a TTY)"
       class_option :interactive, type: :boolean, default: false, desc: "Force interactive mode even when not a TTY"
       class_option :format, type: :string, desc: "Output format: table (default) or json"
-      class_option :dry_run, type: :boolean, default: false, desc: "Simulate command without making network calls"
+      class_option :dry_run, type: :boolean, default: false, desc: "Simulate writes while allowing read lookups"
 
       no_commands do
         def invoke_command(command, *args)
@@ -1066,7 +1066,7 @@ module FreshBooks
           global_flags: {
             "--no-interactive" => "Disable interactive prompts (auto-detected when not a TTY)",
             "--format json"    => "Output format: json (available on all commands)",
-            "--dry-run"        => "Simulate command without making network calls (writes skipped)"
+            "--dry-run"        => "Simulate writes while allowing read lookups"
           },
           commands: {
             auth: {

--- a/spec/freshbooks/api_spec.rb
+++ b/spec/freshbooks/api_spec.rb
@@ -290,16 +290,33 @@ RSpec.describe FreshBooks::CLI::Api do
       Then { result == [{ "id" => 1, "organization" => "Acme" }] }
     end
 
-    describe ".fetch_all_pages returns empty array in dry-run" do
+    describe ".fetch_all_pages makes real GET in dry-run" do
+      Given {
+        stub_request(:get, "https://api.freshbooks.com/fake")
+          .with(query: hash_including("page" => "1", "per_page" => "100"))
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "result" => { "items" => [{ "id" => 1 }], "meta" => { "pages" => 1, "page" => 1 } } }.to_json
+          )
+      }
       When(:result) {
         FreshBooks::CLI::Api.fetch_all_pages("https://api.freshbooks.com/fake", "items")
       }
-      Then { result == [] }
+      Then { result == [{ "id" => 1 }] }
     end
 
-    describe ".fetch_services returns empty array in dry-run (no HTTP)" do
+    describe ".fetch_services makes real GET in dry-run when cache is empty" do
+      Given {
+        stub_request(:get, %r{api\.freshbooks\.com/comments/business/12345/services})
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "result" => { "services" => { "5" => { "id" => 5, "name" => "Dev" } } } }.to_json
+          )
+      }
       When(:result) { FreshBooks::CLI::Api.fetch_services }
-      Then { result == [] }
+      Then { result == [{ "id" => 5, "name" => "Dev" }] }
     end
 
     describe ".fetch_services uses stale cache in dry-run" do
@@ -312,6 +329,24 @@ RSpec.describe FreshBooks::CLI::Api do
       }
       When(:result) { FreshBooks::CLI::Api.fetch_services }
       Then { result == [{ "id" => 5, "name" => "Dev" }] }
+    end
+
+    describe ".fetch_services force: true bypasses stale cache in dry-run" do
+      Given {
+        stale_cache = {
+          "updated_at" => Time.now.to_i - 700,
+          "services_data" => [{ "id" => 5, "name" => "Cached" }]
+        }
+        FreshBooks::CLI::Auth.save_cache(stale_cache)
+        stub_request(:get, %r{api\.freshbooks\.com/comments/business/12345/services})
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { "result" => { "services" => { "6" => { "id" => 6, "name" => "Fresh" } } } }.to_json
+          )
+      }
+      When(:result) { FreshBooks::CLI::Api.fetch_services(force: true) }
+      Then { result == [{ "id" => 6, "name" => "Fresh" }] }
     end
 
     describe ".fetch_time_entry makes real GET in dry-run" do

--- a/spec/freshbooks/cli_spec.rb
+++ b/spec/freshbooks/cli_spec.rb
@@ -1324,6 +1324,7 @@ RSpec.describe FreshBooks::CLI::Commands do
   # --- dry-run integration ---
 
   describe "dry-run integration" do
+    let(:projects_url) { %r{api\.freshbooks\.com/projects/business/12345/projects} }
     let(:stale_cache) {
       {
         "updated_at" => Time.now.to_i - 700,
@@ -1425,6 +1426,42 @@ RSpec.describe FreshBooks::CLI::Commands do
         Then {
           json = JSON.parse(stdout)
           json["_dry_run"]["simulated"] == true
+        }
+      end
+
+      context "resolves project names with read APIs" do
+        Given {
+          stub_request(:get, projects_url)
+            .to_return(
+              status: 200,
+              headers: { "Content-Type" => "application/json" },
+              body: {
+                "result" => {
+                  "projects" => [{ "id" => 12375603, "title" => "Some Internal Project", "client_id" => nil, "internal" => true }],
+                  "meta" => { "pages" => 1, "page" => 1 }
+                }
+              }.to_json
+            )
+        }
+        When(:result) {
+          begin
+            capture_stdout {
+              FreshBooks::CLI::Commands.start([
+                "edit", "--id", "999", "--internal", "--project", "Some Internal Project",
+                "--duration", "2.0", "--yes", "--dry-run", "--format", "json"
+              ])
+            }
+          rescue SystemExit => e
+            e
+          end
+        }
+        Then {
+          payload = JSON.parse(result)["_dry_run"]["payload_sent"]
+          payload["project_id"] == 12375603 && !payload.key?("client_id")
+        }
+        And {
+          assert_requested(:get, projects_url, times: 1)
+          true
         }
       end
     end


### PR DESCRIPTION
## Summary
- allow dry-run paginated and service reads so name resolution matches real commands
- keep write calls simulated under dry-run
- update dry-run help/docs and regression coverage

## Tests
- bundle exec rspec
- git diff --check
