### PR TITLE
fix(cli): improve log help and aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,10 @@ end
 - **No TTY** (pipes, agents, CI): uses flags, auto-selects single options, or aborts with clear errors
 - `--no-interactive` flag forces non-interactive mode
 
+### Agent-Friendly CLI Parsing
+
+`fb log` uses `--duration` and `--note` as canonical scripted flags. It also accepts `--hours` and `--notes` as aliases, and `fb edit` accepts the same aliases for updates. `fb log --help` prints command-specific usage, required non-interactive fields, and examples. Unknown `fb log` options should produce actionable guidance with the unknown flag, required fields, and an example invocation.
+
 ### Auth Flow
 
 Auth supports both interactive (single `fb auth` command) and non-interactive (subcommands) flows:

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ fb log --project "AI Service Design" --service "Meetings" --duration 0.5 --note 
 fb log --internal --project "AI Service Design" --service "Meetings" --duration 0.5 --note "Calum 1:1" --yes --format json
 ```
 
+`--duration` and `--note` are the canonical scripted flags. `--hours` and `--notes` are accepted aliases for callers that guess those names. Run `fb log --help` for command-specific usage, required non-interactive fields, and examples.
+
 **Notes:**
 - Services are project-scoped. Use `fb projects --format json` to see available services per project.
 - Internal projects can be logged without `--client`.
@@ -294,6 +296,8 @@ fb edit --id 12345 --project "AI Service Design" --service "Meetings" --yes
 fb edit --id 12345 --internal --project "AI Service Design" --service "Meetings" --yes
 fb edit --id 12345 --duration 2 --yes --format json  # JSON output
 ```
+
+`--duration` and `--note` remain the canonical edit flags. `--hours` and `--notes` are accepted aliases.
 
 When `--project` points to an internal project, `fb edit` omits `client_id` from the update payload so the entry becomes clientless.
 

--- a/docs/plans/2026-05-12-agent-friendly-log-help.md
+++ b/docs/plans/2026-05-12-agent-friendly-log-help.md
@@ -1,0 +1,280 @@
+# Agent-Friendly Log Help Implementation Plan
+
+**Goal:** Make `fb log` easier for scripted callers to recover from common parse and help mistakes.
+
+**Architecture:** Keep `--duration` and `--note` as the canonical options while adding Thor aliases for common guesses. Add command-specific help text through Thor's existing description APIs, and add a narrow Thor parse-error hook that improves `fb log` unknown-option messages without changing command execution paths.
+
+**Tech Stack:** Ruby, Thor, RSpec, rspec-given, WebMock.
+
+---
+
+### Task 0: Post This Design To Issue #18
+
+**Files:**
+- Read: `docs/plans/2026-05-12-agent-friendly-log-help.md`
+
+- [ ] Post the full text of this plan to GitHub issue #18 as a comment so the implementation design is durable in the tracker.
+
+Run:
+
+```bash
+gh issue comment 18 --repo parasquid/freshbooks-cli --body-file docs/plans/2026-05-12-agent-friendly-log-help.md
+```
+
+Expected: GitHub accepts the comment.
+
+### Task 1: Add Failing Specs For Log Aliases
+
+**Files:**
+- Modify: `spec/freshbooks/cli_spec.rb`
+
+- [ ] Add a `log` spec proving `--hours` and `--notes` work like `--duration` and `--note`.
+
+Add this context under `describe "log"` after the existing non-interactive JSON spec:
+
+```ruby
+    context "non-interactive accepts common duration and note aliases" do
+      Given { stub_log_apis }
+      When(:output) {
+        capture_stdout {
+          FreshBooks::CLI::Commands.start(["log", "--client", "Acme Corp", "--hours", "2.5", "--notes", "test work", "--yes", "--format", "json"])
+        }
+      }
+      Then {
+        json = JSON.parse(output)
+        json["result"]["time_entry"]["duration"] == 9000 &&
+          json["result"]["time_entry"]["note"] == "test work"
+      }
+    end
+```
+
+- [ ] Run the focused spec and confirm it fails because Thor does not recognize `--hours` or `--notes`.
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/cli_spec.rb:717
+```
+
+Expected: FAIL with an unknown option mentioning `--hours`.
+
+### Task 2: Implement Log And Edit Aliases
+
+**Files:**
+- Modify: `lib/freshbooks/cli.rb`
+
+- [ ] Add aliases to the existing options:
+
+```ruby
+      method_option :duration, type: :numeric, aliases: "--hours", desc: "Duration in hours (e.g. 2.5)"
+      method_option :note, type: :string, aliases: "--notes", desc: "Work description"
+```
+
+Apply the same aliases to the `edit` command:
+
+```ruby
+      method_option :duration, type: :numeric, aliases: "--hours", desc: "New duration in hours"
+      method_option :note, type: :string, aliases: "--notes", desc: "New note"
+```
+
+- [ ] Run the focused log spec and confirm it passes.
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/cli_spec.rb:717
+```
+
+Expected: PASS.
+
+### Task 3: Add Failing Specs For Log Help
+
+**Files:**
+- Modify: `spec/freshbooks/cli_spec.rb`
+
+- [ ] Add a spec proving `fb log --help` exits successfully and prints command-specific guidance.
+
+Add this near the existing `describe "help command"` block:
+
+```ruby
+  describe "log help" do
+    When(:output) {
+      capture_stdout {
+        FreshBooks::CLI::Commands.start(["log", "--help"])
+      }
+    }
+    Then { output.include?("fb log [--client NAME] [--project NAME] [--service NAME] --duration HOURS --note TEXT") }
+    Then { output.include?("--hours") }
+    Then { output.include?("fb log --project \"Sample Project\" --service \"Development\" --duration 0.5 --note \"Reviewed pull requests\" --yes") }
+  end
+```
+
+- [ ] Run the focused help spec and confirm it fails because current help is too terse or treated as invalid.
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/cli_spec.rb:<new-line-number>
+```
+
+Expected: FAIL before the help text is added.
+
+### Task 4: Implement Rich Log Help
+
+**Files:**
+- Modify: `lib/freshbooks/cli.rb`
+
+- [ ] Replace the current `desc "log", "Log a time entry"` line with a richer usage and long description:
+
+```ruby
+      desc "log [--client NAME] [--project NAME] [--service NAME] --duration HOURS --note TEXT [--date YYYY-MM-DD] [--internal] [--yes]",
+        "Log a time entry"
+      long_desc <<~DESC
+        Log a FreshBooks time entry.
+
+        Non-interactive usage requires --duration and --note. Use --client when multiple clients exist, or --internal with --project for internal work.
+
+        Examples:
+          fb log --project "Sample Project" --service "Development" --duration 0.5 --note "Reviewed pull requests" --yes
+          fb log --internal --project "Admin" --hours 1 --notes "Planning" --yes
+      DESC
+```
+
+- [ ] Run the focused help spec and confirm it passes.
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/cli_spec.rb:<new-line-number>
+```
+
+Expected: PASS.
+
+### Task 5: Add Failing Spec For Unknown Log Option Guidance
+
+**Files:**
+- Modify: `spec/freshbooks/cli_spec.rb`
+
+- [ ] Add a spec proving unknown `fb log` flags return actionable guidance.
+
+Add this under `describe "log"`:
+
+```ruby
+    context "unknown log option prints actionable guidance" do
+      When(:result) {
+        capture_stderr {
+          capture_stdout {
+            begin
+              FreshBooks::CLI::Commands.start(["log", "--duration", "0.5", "--details", "x"])
+            rescue SystemExit => e
+              e
+            end
+          }
+        }
+      }
+      Then { result.include?("Unknown option: --details") }
+      Then { result.include?("fb log requires:") }
+      Then { result.include?("--duration HOURS") }
+      Then { result.include?("--note TEXT") }
+      Then { result.include?("Example:") }
+    end
+```
+
+- [ ] Run the focused spec and confirm it fails because current Thor output is terse.
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/cli_spec.rb:<new-line-number>
+```
+
+Expected: FAIL before custom guidance exists.
+
+### Task 6: Implement Narrow Unknown Option Guidance
+
+**Files:**
+- Modify: `lib/freshbooks/cli.rb`
+
+- [ ] Add a class-level Thor failure hook that only special-cases `fb log` unknown options and delegates everything else to the default behavior.
+
+Add this near `self.exit_on_failure?`:
+
+```ruby
+      def self.dispatch(m, args, options, config)
+        super
+      rescue Thor::UnknownArgumentError, Thor::UnknownArgumentError => e
+        raise unless m.to_s == "log"
+
+        unknown_option = e.message[/--[A-Za-z0-9_-]+/]
+        message = log_parse_error_message(unknown_option, e.message)
+        $stderr.puts message
+        exit(1)
+      end
+```
+
+Then add a helper:
+
+```ruby
+      def self.log_parse_error_message(option, fallback)
+        suggestion = { "--hours" => "--duration", "--notes" => "--note" }[option]
+        lines = ["Unknown option: #{option || fallback}"]
+        lines << "Did you mean: #{suggestion}" if suggestion
+        lines.concat([
+          "",
+          "fb log requires:",
+          "  --duration HOURS",
+          "  --note TEXT",
+          "",
+          "Example:",
+          '  fb log --project "Sample Project" --service "Development" --duration 0.5 --note "Reviewed pull requests" --yes'
+        ])
+        lines.join("\n")
+      end
+```
+
+If Thor exposes the error as a different class in this version, inspect the failing spec output and catch that exact Thor class.
+
+- [ ] Run the focused unknown-option spec and confirm it passes.
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/cli_spec.rb:<new-line-number>
+```
+
+Expected: PASS.
+
+### Task 7: Update Documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify if present/relevant: `skills/freshbooks/SKILL.md`
+
+- [ ] Document that `fb log` accepts `--hours`/`--notes` as aliases for `--duration`/`--note`, while keeping the canonical names clear.
+- [ ] Document that `fb log --help` is the first recovery path for scripted callers that need command shape examples.
+
+### Task 8: Full Verification
+
+**Files:**
+- No source edits.
+
+- [ ] Run the full suite.
+
+Run:
+
+```bash
+bundle exec rspec
+```
+
+Expected: `0 failures`.
+
+- [ ] Run whitespace verification.
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.

--- a/lib/freshbooks/cli.rb
+++ b/lib/freshbooks/cli.rb
@@ -13,6 +13,44 @@ module FreshBooks
         true
       end
 
+      def self.dispatch(command, given_args, given_opts, config)
+        requested_command = command || given_args.first
+
+        super
+      rescue Thor::UnknownArgumentError => e
+        if requested_command.to_s == "log"
+          unknown_option = e.unknown.first
+          raise Thor::InvocationError, log_parse_error_message(unknown_option, e.message)
+        end
+
+        raise
+      end
+
+      def self.handle_argument_error(command, error, args, arity)
+        unknown_option = args.find { |arg| arg.to_s.start_with?("--") }
+        if command.name == "log" && unknown_option
+          raise Thor::InvocationError, log_parse_error_message(unknown_option, error.message)
+        end
+
+        super
+      end
+
+      def self.log_parse_error_message(option, fallback)
+        suggestion = { "--hours" => "--duration", "--notes" => "--note" }[option]
+        lines = ["Unknown option: #{option || fallback}"]
+        lines << "Did you mean: #{suggestion}" if suggestion
+        lines.concat([
+          "",
+          "fb log requires:",
+          "  --duration HOURS",
+          "  --note TEXT",
+          "",
+          "Example:",
+          '  fb log --project "Sample Project" --service "Development" --duration 0.5 --note "Reviewed pull requests" --yes'
+        ])
+        lines.join("\n")
+      end
+
       class_option :no_interactive, type: :boolean, default: false, desc: "Disable interactive prompts (auto-detected when not a TTY)"
       class_option :interactive, type: :boolean, default: false, desc: "Force interactive mode even when not a TTY"
       class_option :format, type: :string, desc: "Output format: table (default) or json"
@@ -210,16 +248,32 @@ module FreshBooks
 
       # --- log ---
 
-      desc "log", "Log a time entry"
+      desc "log [--client NAME] [--project NAME] [--service NAME] --duration HOURS --note TEXT [--date YYYY-MM-DD] [--internal] [--yes]",
+        "Log a time entry"
+      long_desc <<~DESC
+        Log a FreshBooks time entry.
+
+        Non-interactive usage requires --duration and --note. Use --client when multiple clients exist, or --internal with --project for internal work.
+
+        Examples:
+          fb log --project "Sample Project" --service "Development" --duration 0.5 --note "Reviewed pull requests" --yes
+          fb log --internal --project "Admin" --hours 1 --notes "Planning" --yes
+      DESC
       method_option :client, type: :string, desc: "Pre-select client by name"
       method_option :project, type: :string, desc: "Pre-select project by name"
       method_option :service, type: :string, desc: "Pre-select service by name"
-      method_option :duration, type: :numeric, desc: "Duration in hours (e.g. 2.5)"
-      method_option :note, type: :string, desc: "Work description"
+      method_option :duration, type: :numeric, aliases: "--hours", desc: "Duration in hours (e.g. 2.5)"
+      method_option :note, type: :string, aliases: "--notes", desc: "Work description"
       method_option :date, type: :string, desc: "Date (YYYY-MM-DD, defaults to today)"
       method_option :internal, type: :boolean, default: false, desc: "Log to an internal project with no client"
       method_option :yes, type: :boolean, default: false, desc: "Skip confirmation"
+      method_option :help, type: :boolean, desc: "Show command help"
       def log
+        if options[:help]
+          self.class.command_help(shell, "log")
+          return
+        end
+
         Auth.valid_access_token
         defaults = Auth.load_defaults
 
@@ -517,8 +571,8 @@ module FreshBooks
 
       desc "edit", "Edit a time entry"
       method_option :id, type: :numeric, desc: "Time entry ID (skip interactive picker)"
-      method_option :duration, type: :numeric, desc: "New duration in hours"
-      method_option :note, type: :string, desc: "New note"
+      method_option :duration, type: :numeric, aliases: "--hours", desc: "New duration in hours"
+      method_option :note, type: :string, aliases: "--notes", desc: "New note"
       method_option :date, type: :string, desc: "New date (YYYY-MM-DD)"
       method_option :client, type: :string, desc: "New client name"
       method_option :project, type: :string, desc: "New project name"

--- a/skills/freshbooks/SKILL.md
+++ b/skills/freshbooks/SKILL.md
@@ -113,6 +113,7 @@ When executing `fb` commands:
 - **Always** use `--id` for `edit` and `delete` commands
 - Parse JSON output to extract entry IDs, totals, and status
 - After each mutation (`log`, `edit`, `delete`), run one verification read (`fb entries ... --format json` or `fb status --format json`) and report the result.
+- For `fb log` and `fb edit`, prefer canonical `--duration` and `--note`. The CLI also accepts `--hours` and `--notes` aliases. If command shape is unclear, run `fb log --help` before retrying.
 
 **Important: Services are project-scoped and MUST always be specified when logging time.** `fb services` may return empty — services are embedded in project data. Use `--service "Name"` with the service name from the project (visible in `fb projects --format json` under the `services` array). Common service names: Development, Research, General, Meetings. Infer the service from context clues in the user's request (e.g. "development work" → "Development", "a meeting" → "Meetings"). If the service cannot be inferred, ask the user before logging.
 
@@ -132,6 +133,7 @@ fb log --project "AI Service Design" --service "Meetings" --duration 0.5 --note 
 fb log --internal --project "AI Service Design" --service "Meetings" --duration 0.5 --note "Calum 1:1" --yes --format json
 # --project is required when multiple projects are possible and should be supplied for deterministic automation.
 # --date is optional; --duration, --note, and --service are required.
+# --hours is accepted as an alias for --duration; --notes is accepted as an alias for --note.
 # --client is required only for client-backed project resolution when the project does not determine the client.
 # --internal requires --project and conflicts with --client.
 # IMPORTANT: Always include --service. Infer the service from context (e.g. "development work" → "Development",
@@ -146,6 +148,7 @@ fb edit --id ENTRY_ID --service "Meetings" --yes --format json
 fb edit --id ENTRY_ID --project "AI Service Design" --service "Meetings" --yes --format json
 fb edit --id ENTRY_ID --internal --project "AI Service Design" --service "Meetings" --yes --format json
 # Edit preserves all existing fields — only specified flags are changed
+# --hours is accepted as an alias for --duration; --notes is accepted as an alias for --note.
 ```
 
 ### Delete Entry

--- a/spec/freshbooks/cli_spec.rb
+++ b/spec/freshbooks/cli_spec.rb
@@ -582,6 +582,25 @@ RSpec.describe FreshBooks::CLI::Commands do
       }
     end
 
+    context "accepts common duration and note aliases" do
+      Given { stub_edit_apis }
+      When(:output) {
+        capture_stdout {
+          FreshBooks::CLI::Commands.start(["edit", "--id", "999", "--hours", "1.5", "--notes", "Updated note", "--yes", "--format", "json"])
+        }
+      }
+      Then {
+        json = JSON.parse(output)
+        response_matches = json["result"]["time_entry"]["id"] == 999
+        assert_requested(:put, entry_url) { |req|
+          entry = JSON.parse(req.body).fetch("time_entry")
+          entry["duration"] == 5400 &&
+            entry["note"] == "Updated note"
+        }
+        response_matches
+      }
+    end
+
     context "non-interactive without --id aborts" do
       Given {
         allow($stdin).to receive(:tty?).and_return(false)
@@ -782,6 +801,45 @@ RSpec.describe FreshBooks::CLI::Commands do
         json = JSON.parse(output)
         json["result"]["time_entry"]["id"] == 555
       }
+    end
+
+    context "non-interactive accepts common duration and note aliases" do
+      Given { stub_log_apis }
+      When(:output) {
+        capture_stdout {
+          FreshBooks::CLI::Commands.start(["log", "--client", "Acme Corp", "--hours", "2.5", "--notes", "test work", "--yes", "--format", "json"])
+        }
+      }
+      Then {
+        json = JSON.parse(output)
+        response_matches = json["result"]["time_entry"]["duration"] == 9000 &&
+          json["result"]["time_entry"]["note"] == "test work"
+        assert_requested(:post, time_entries_url) { |req|
+          entry = JSON.parse(req.body).fetch("time_entry")
+          entry["duration"] == 9000 &&
+            entry["note"] == "test work"
+        }
+        response_matches
+      }
+    end
+
+    context "unknown log option prints actionable guidance" do
+      When(:result) {
+        capture_stderr {
+          capture_stdout {
+            begin
+              FreshBooks::CLI::Commands.start(["log", "--duration", "0.5", "--details", "x"])
+            rescue SystemExit
+              nil
+            end
+          }
+        }
+      }
+      Then { result.include?("Unknown option: --details") }
+      Then { result.include?("fb log requires:") }
+      Then { result.include?("--duration HOURS") }
+      Then { result.include?("--note TEXT") }
+      Then { result.include?("Example:") }
     end
 
     context "non-interactive missing --duration aborts" do
@@ -1310,6 +1368,18 @@ RSpec.describe FreshBooks::CLI::Commands do
       capture_stdout { FreshBooks::CLI::Commands.start(["help", "--format", "json"]) }
     }
     Then { JSON.parse(output)["global_flags"].key?("--dry-run") }
+  end
+
+  describe "log help" do
+    When(:output) {
+      capture_stdout {
+        FreshBooks::CLI::Commands.start(["log", "--help"])
+      }
+    }
+    Then { output.include?("log [--client NAME] [--project NAME] [--service NAME] --duration HOURS --note TEXT") }
+    Then { output.include?("--hours") }
+    Then { output.include?("Sample Project") }
+    Then { output.include?("Reviewed pull requests") }
   end
 
   # --- dry-run banner ---


### PR DESCRIPTION
## Summary
- add --hours/--notes aliases for log and edit while keeping canonical --duration/--note flags
- make fb log --help render command-specific usage, requirements, and examples
- improve unknown fb log option guidance and document the recovery path

## Tests
- bundle exec rspec
- git diff --check
