### PR TITLE
fix(auth): refresh tokens during status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Auth supports both interactive (single `fb auth` command) and non-interactive (s
 - `fb auth setup` — writes credentials to `<data_dir>/.env` (interactive: prompts with masked secret; non-interactive: reads from `FRESHBOOKS_CLIENT_ID`/`FRESHBOOKS_CLIENT_SECRET` env vars or `<data_dir>/.env`)
 - `fb auth url` — prints OAuth URL
 - `fb auth callback REDIRECT_URL` — exchanges code for tokens, auto-selects single business
-- `fb auth status` — shows current auth state
+- `fb auth status` — shows current auth state and silently refreshes stale access tokens when refresh is possible; scripted callers should branch on `requires_reauth`, not raw `tokens_expired`
 - `fb business --select ID` — sets active business (required for multi-business accounts)
 
 ### Config Directory Resolution

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ fb auth status                 # human-readable
 fb auth status --format json   # structured output
 ```
 
-Tokens auto-refresh before every API call — no need to re-auth unless you revoke app access. Refresh is serialized across concurrent `fb` processes so parallel commands can reuse the newly written token.
+Tokens auto-refresh before every API call, and `fb auth status` also attempts the same silent refresh when the access token is stale. In JSON output, scripts should branch on `requires_reauth`; `tokens_expired` only remains true after status when browser re-auth is actually needed. Refresh is serialized across concurrent `fb` processes so parallel commands can reuse the newly written token.
 
 ### `fb business`
 
@@ -330,6 +330,7 @@ The CLI is designed to be fully scriptable. All commands support `--format json`
 # Preflight (recommended)
 command -v fb >/dev/null 2>&1
 fb auth status --format json
+# In JSON output, ask for browser OAuth only when requires_reauth is true.
 
 # 1. Save credentials (via env vars or <data_dir>/.env)
 export FRESHBOOKS_CLIENT_ID=YOUR_ID

--- a/docs/plans/2026-05-12-auth-status-refresh.md
+++ b/docs/plans/2026-05-12-auth-status-refresh.md
@@ -1,0 +1,109 @@
+# Auth Status Refresh Implementation Plan
+
+**Goal:** Make `fb auth status` report whether browser re-auth is actually required, not merely whether the access token is stale.
+
+**Architecture:** Keep token refresh behavior in `FreshBooks::CLI::Auth`, reusing the existing locked refresh path. `auth_status` will attempt a silent refresh when config and expired tokens are present, then return status based on the post-refresh token state. If refresh is impossible or fails, status remains reportable and includes `requires_reauth: true`.
+
+**Tech Stack:** Ruby, Thor, HTTParty, RSpec, rspec-given, WebMock.
+
+---
+
+### Task 0: Post This Design To Issue #17
+
+**Files:**
+- Read: `docs/plans/2026-05-12-auth-status-refresh.md`
+
+- [ ] Post the full text of this plan to GitHub issue #17 as a comment.
+
+Run:
+
+```bash
+gh issue comment 17 --repo parasquid/freshbooks-cli --body-file docs/plans/2026-05-12-auth-status-refresh.md
+```
+
+Expected: GitHub accepts the comment.
+
+### Task 1: Add Failing Auth Specs
+
+**Files:**
+- Modify: `spec/freshbooks/auth_spec.rb`
+
+- [ ] Add coverage showing `auth_status` silently refreshes stale tokens when a refresh token and config exist.
+- [ ] Add coverage showing `auth_status` reports `requires_reauth: true` without aborting when refresh fails.
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/auth_spec.rb:450
+```
+
+Expected before implementation: failures showing `tokens_expired` remains true and/or refresh failure aborts.
+
+### Task 2: Implement Silent Refresh In Auth Status
+
+**Files:**
+- Modify: `lib/freshbooks/auth.rb`
+
+- [ ] Update `auth_status` to load config and tokens, attempt `refresh_token_with_lock(config, tokens)` when tokens are expired and config exists, and return refreshed token status when successful.
+- [ ] Add `requires_reauth` to the returned hash. It should be true when config is missing, tokens are missing, tokens remain expired after refresh, or refresh fails.
+- [ ] Rescue `SystemExit` from refresh failure so `fb auth status` can report status instead of terminating early.
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/auth_spec.rb:450
+```
+
+Expected after implementation: focused auth status specs pass.
+
+### Task 3: Add CLI Status Coverage
+
+**Files:**
+- Modify: `spec/freshbooks/cli_spec.rb`
+
+- [ ] Add or update CLI specs to prove `fb auth status --format json` includes `requires_reauth`.
+- [ ] Add or update table-output specs to prove `fb auth status` shows whether re-auth is required.
+
+Run:
+
+```bash
+bundle exec rspec spec/freshbooks/cli_spec.rb:1180
+```
+
+Expected: focused CLI auth status specs pass.
+
+### Task 4: Update Documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `skills/freshbooks/SKILL.md`
+
+- [ ] Document that `fb auth status` may silently refresh expired access tokens.
+- [ ] Document that scripted callers should branch on `requires_reauth`, not `tokens_expired`.
+- [ ] Update FreshBooks skill auth guidance to try normal reads or branch on `requires_reauth` before asking for browser OAuth.
+
+### Task 5: Full Verification
+
+**Files:**
+- No source edits.
+
+- [ ] Run the full test suite.
+
+Run:
+
+```bash
+bundle exec rspec
+```
+
+Expected: `0 failures`.
+
+- [ ] Run whitespace verification.
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.

--- a/lib/freshbooks/auth.rb
+++ b/lib/freshbooks/auth.rb
@@ -9,6 +9,8 @@ require "dotenv"
 module FreshBooks
   module CLI
     class Auth
+      class TokenRefreshError < StandardError; end
+
       TOKEN_URL = "https://api.freshbooks.com/auth/oauth/token"
       AUTH_URL = "https://auth.freshbooks.com/oauth/authorize"
       ME_URL = "https://api.freshbooks.com/auth/api/v1/users/me"
@@ -204,14 +206,28 @@ module FreshBooks
         def auth_status
           config = load_config
           tokens = load_tokens
+          refresh_error = nil
+
+          if config && tokens && token_expired?(tokens)
+            begin
+              tokens = refresh_token_with_lock(config, tokens, abort_on_failure: false)
+            rescue TokenRefreshError => e
+              refresh_error = e.message
+            end
+          end
+
+          tokens_expired = tokens ? token_expired?(tokens) : nil
+          requires_reauth = config.nil? || tokens.nil? || tokens_expired == true
           {
             "config_exists" => !config.nil?,
             "config_path" => config_path,
             "tokens_exist" => !tokens.nil?,
-            "tokens_expired" => tokens ? token_expired?(tokens) : nil,
+            "tokens_expired" => tokens_expired,
+            "requires_reauth" => requires_reauth,
+            "refresh_error" => refresh_error,
             "business_id" => config&.dig("business_id"),
             "account_id" => config&.dig("account_id")
-          }
+          }.compact
         end
 
         def fetch_businesses(access_token)
@@ -280,22 +296,30 @@ module FreshBooks
           Time.now.to_i >= (created + expires_in - 60)
         end
 
-        def refresh_token!(config, tokens)
-          response = HTTParty.post(TOKEN_URL, {
-            headers: { "Content-Type" => "application/json" },
-            body: {
-              grant_type: "refresh_token",
-              client_id: config["client_id"],
-              client_secret: config["client_secret"],
-              redirect_uri: REDIRECT_URI,
-              refresh_token: tokens["refresh_token"]
-            }.to_json
-          })
+        def refresh_token!(config, tokens, abort_on_failure: true)
+          begin
+            response = HTTParty.post(TOKEN_URL, {
+              headers: { "Content-Type" => "application/json" },
+              body: {
+                grant_type: "refresh_token",
+                client_id: config["client_id"],
+                client_secret: config["client_secret"],
+                redirect_uri: REDIRECT_URI,
+                refresh_token: tokens["refresh_token"]
+              }.to_json
+            })
+          rescue StandardError => e
+            message = "Token refresh failed: #{e.class}: #{e.message}\nPlease re-run: fb auth"
+            raise if abort_on_failure
+            raise TokenRefreshError, message
+          end
 
           unless response.success?
             body = response.parsed_response
             msg = body.is_a?(Hash) ? (body["error_description"] || body["error"] || response.body) : response.body
-            abort("Token refresh failed: #{msg}\nPlease re-run: fb auth")
+            message = "Token refresh failed: #{msg}\nPlease re-run: fb auth"
+            abort(message) if abort_on_failure
+            raise TokenRefreshError, message
           end
 
           data = response.parsed_response
@@ -309,7 +333,7 @@ module FreshBooks
           new_tokens
         end
 
-        def refresh_token_with_lock(config, tokens)
+        def refresh_token_with_lock(config, tokens, abort_on_failure: true)
           ensure_data_dir
           File.open(tokens_lock_path, File::RDWR | File::CREAT, 0o600) do |lock_file|
             lock_file.flock(File::LOCK_EX)
@@ -317,7 +341,7 @@ module FreshBooks
             latest_tokens = load_tokens || tokens
             return latest_tokens if latest_tokens && !token_expired?(latest_tokens)
 
-            refresh_token!(config, latest_tokens || tokens)
+            refresh_token!(config, latest_tokens || tokens, abort_on_failure: abort_on_failure)
           ensure
             lock_file.flock(File::LOCK_UN)
           end

--- a/lib/freshbooks/cli.rb
+++ b/lib/freshbooks/cli.rb
@@ -162,6 +162,7 @@ module FreshBooks
             if status_data["tokens_exist"]
               puts "Expired: #{status_data["tokens_expired"] ? "yes" : "no"}"
             end
+            puts "Requires re-auth: #{status_data["requires_reauth"] ? "yes" : "no"}"
             puts "Business ID: #{status_data["business_id"] || "not set"}"
             puts "Account ID: #{status_data["account_id"] || "not set"}"
           end

--- a/skills/freshbooks/SKILL.md
+++ b/skills/freshbooks/SKILL.md
@@ -56,11 +56,11 @@ Use `fb auth status --format json` and branch exactly once per blocker:
    - If response contains `"business_selected": false`:
      - Ask only for business ID, then run `fb business --select ID --format json`
 
-4. If `tokens_exist` is `true` and `tokens_expired` is `true`:
-   - Run: `fb clients --format json`
-   - If it succeeds, the CLI refreshed tokens automatically; continue with the auth state machine.
-   - If it fails with a token refresh or authorization error, run: `fb auth url --format json`
+4. If `requires_reauth` is `true`:
+   - Run: `fb auth url --format json`
    - Ask only for full redirect URL
+
+`fb auth status` silently refreshes stale access tokens when the refresh token is still usable. Do not ask for browser OAuth because `tokens_expired` was true in older output; branch on `requires_reauth` from current JSON output.
 
 5. If `tokens_exist` is `true` but `business_id` is null:
    - Run: `fb business --format json`

--- a/spec/freshbooks/auth_spec.rb
+++ b/spec/freshbooks/auth_spec.rb
@@ -446,6 +446,7 @@ RSpec.describe FreshBooks::CLI::Auth do
       When(:result) { FreshBooks::CLI::Auth.auth_status }
       Then { result["config_exists"] == false }
       And  { result["tokens_exist"] == false }
+      And  { result["requires_reauth"] == true }
     end
 
     context "with config and tokens" do
@@ -463,7 +464,93 @@ RSpec.describe FreshBooks::CLI::Auth do
       Then { result["config_exists"] == true }
       And  { result["tokens_exist"] == true }
       And  { result["tokens_expired"] == false }
+      And  { result["requires_reauth"] == false }
       And  { result["business_id"] == 123 }
+    end
+
+    context "with expired access token and refreshable credentials" do
+      Given {
+        ENV["FRESHBOOKS_CLIENT_ID"] = "id"
+        ENV["FRESHBOOKS_CLIENT_SECRET"] = "sec"
+        FreshBooks::CLI::Auth.save_config("business_id" => 123, "account_id" => "acc")
+        FreshBooks::CLI::Auth.save_tokens(
+          "access_token" => "old_access",
+          "refresh_token" => "refresh_me",
+          "expires_in" => 3600,
+          "created_at" => Time.now.to_i - 7200
+        )
+        stub_request(:post, FreshBooks::CLI::Auth::TOKEN_URL)
+          .with { |req| JSON.parse(req.body)["refresh_token"] == "refresh_me" }
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: {
+              "access_token" => "new_access",
+              "refresh_token" => "new_refresh",
+              "expires_in" => 3600
+            }.to_json
+          )
+      }
+      after {
+        ENV.delete("FRESHBOOKS_CLIENT_ID")
+        ENV.delete("FRESHBOOKS_CLIENT_SECRET")
+      }
+      When(:result) { FreshBooks::CLI::Auth.auth_status }
+      Then { result["tokens_expired"] == false }
+      And  { result["requires_reauth"] == false }
+      And  { FreshBooks::CLI::Auth.load_tokens["access_token"] == "new_access" }
+    end
+
+    context "with expired access token and failed refresh" do
+      Given {
+        ENV["FRESHBOOKS_CLIENT_ID"] = "id"
+        ENV["FRESHBOOKS_CLIENT_SECRET"] = "sec"
+        FreshBooks::CLI::Auth.save_config("business_id" => 123, "account_id" => "acc")
+        FreshBooks::CLI::Auth.save_tokens(
+          "access_token" => "old_access",
+          "refresh_token" => "bad_refresh",
+          "expires_in" => 3600,
+          "created_at" => Time.now.to_i - 7200
+        )
+        stub_request(:post, FreshBooks::CLI::Auth::TOKEN_URL)
+          .to_return(
+            status: 401,
+            headers: { "Content-Type" => "application/json" },
+            body: { "error" => "invalid_grant" }.to_json
+          )
+      }
+      after {
+        ENV.delete("FRESHBOOKS_CLIENT_ID")
+        ENV.delete("FRESHBOOKS_CLIENT_SECRET")
+      }
+      When(:result) { FreshBooks::CLI::Auth.auth_status }
+      Then { result["tokens_expired"] == true }
+      And  { result["requires_reauth"] == true }
+      And  { result["refresh_error"].include?("Token refresh failed") }
+    end
+
+    context "with expired access token and refresh transport failure" do
+      Given {
+        ENV["FRESHBOOKS_CLIENT_ID"] = "id"
+        ENV["FRESHBOOKS_CLIENT_SECRET"] = "sec"
+        FreshBooks::CLI::Auth.save_config("business_id" => 123, "account_id" => "acc")
+        FreshBooks::CLI::Auth.save_tokens(
+          "access_token" => "old_access",
+          "refresh_token" => "timeout_refresh",
+          "expires_in" => 3600,
+          "created_at" => Time.now.to_i - 7200
+        )
+        stub_request(:post, FreshBooks::CLI::Auth::TOKEN_URL)
+          .to_timeout
+      }
+      after {
+        ENV.delete("FRESHBOOKS_CLIENT_ID")
+        ENV.delete("FRESHBOOKS_CLIENT_SECRET")
+      }
+      When(:result) { FreshBooks::CLI::Auth.auth_status }
+      Then { result["tokens_expired"] == true }
+      And  { result["requires_reauth"] == true }
+      And  { result["refresh_error"].include?("Token refresh failed") }
     end
   end
 

--- a/spec/freshbooks/cli_spec.rb
+++ b/spec/freshbooks/cli_spec.rb
@@ -1216,6 +1216,7 @@ RSpec.describe FreshBooks::CLI::Commands do
       }
       Then { output.include?("Config:") }
       And  { output.include?("Tokens:") }
+      And  { output.include?("Requires re-auth:") }
     end
 
     context "status with --format json" do
@@ -1224,7 +1225,7 @@ RSpec.describe FreshBooks::CLI::Commands do
       }
       Then {
         json = JSON.parse(output)
-        json.key?("config_exists") && json.key?("tokens_exist")
+        json.key?("config_exists") && json.key?("tokens_exist") && json.key?("requires_reauth")
       }
     end
 


### PR DESCRIPTION
## Summary
- make fb auth status silently refresh stale access tokens when refresh is possible
- add requires_reauth and refresh_error status fields for scripted callers
- keep status structured when refresh fails, including transport failures
- update docs and FreshBooks skill guidance to branch on requires_reauth

## Tests
- bundle exec rspec
- git diff --check
