### PR TITLE
ci(release): opt into node 24 actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - lib/freshbooks/version.rb
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,11 @@ rspec
 # Bump lib/freshbooks/version.rb on master and push the commit.
 # GitHub Actions publishes the gem via trusted publishing and creates the GitHub Release.
 # The release workflow can also be triggered manually from GitHub via workflow_dispatch.
+# A release is successful only after verifying all of:
+#   1. GitHub Actions release workflow completed successfully
+#   2. GitHub Release exists for vX.Y.Z
+#   3. git tag vX.Y.Z exists locally after git fetch --tags
+#   4. RubyGems reports the new version, e.g. gem info freshbooks-cli --remote
 ```
 
 ## Architecture

--- a/docs/plans/2026-05-12-release-node24-warning.md
+++ b/docs/plans/2026-05-12-release-node24-warning.md
@@ -1,0 +1,63 @@
+# Release Node 20 Warning Cleanup Plan
+
+**Goal:** Remove the GitHub Actions Node 20 deprecation warning from the release workflow and document RubyGems verification as part of release success.
+
+**Architecture:** Keep the existing release workflow and trusted publishing action. Since `rubygems/release-gem` is already on its latest release, opt the workflow into Node 24 JavaScript action execution using the runner-supported environment flag. Update durable repo guidance so releases are verified on GitHub Actions, GitHub Releases, git tags, and RubyGems.
+
+**Tech Stack:** GitHub Actions, RubyGems trusted publishing, Ruby.
+
+---
+
+### Task 0: Post This Design To Issue #24
+
+**Files:**
+- Read: `docs/plans/2026-05-12-release-node24-warning.md`
+
+- [ ] Post the full text of this plan to GitHub issue #24 as a comment.
+
+Run:
+
+```bash
+gh issue comment 24 --repo parasquid/freshbooks-cli --body-file docs/plans/2026-05-12-release-node24-warning.md
+```
+
+Expected: GitHub accepts the comment.
+
+### Task 1: Opt Release Workflow Into Node 24
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+- [ ] Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at workflow scope so JavaScript actions in the release job run on Node 24 before the platform default changes.
+
+### Task 2: Document Release Verification
+
+**Files:**
+- Modify: `AGENTS.md`
+
+- [ ] Update release guidance to say a release is successful only after all of these are verified: release workflow success, GitHub Release exists, `vX.Y.Z` tag exists, and RubyGems reports the new `freshbooks-cli` version.
+
+### Task 3: Verify
+
+**Files:**
+- No source edits.
+
+- [ ] Run the test suite.
+
+Run:
+
+```bash
+bundle exec rspec
+```
+
+Expected: `0 failures`.
+
+- [ ] Run whitespace verification.
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.


### PR DESCRIPTION
## Summary
- opt release workflow JavaScript actions into Node 24 to avoid the Node 20 deprecation warning
- document that release success requires RubyGems verification in addition to GitHub Actions, release, and tag checks
- add the #24 implementation plan under docs/plans

## Tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow YAML parsed"'
- bundle exec rspec
- git diff --check
